### PR TITLE
NIAD-823: fix warnings in gradle build file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,7 @@ group = 'uk.nhs.digital.nhsconnect'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
-application {
-	mainClass.set('uk.nhs.digital.nhsconnect.lab.results.IntegrationAdapterLabResultsApplication')
-}
+mainClassName = 'uk.nhs.digital.nhsconnect.lab.results.IntegrationAdapterLabResultsApplication'
 
 sourceSets {
 	intTest {

--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,15 @@ plugins {
 	id 'org.springframework.boot' version '2.4.1'
 	id 'io.spring.dependency-management' version '1.0.10.RELEASE'
 	id 'java'
+	id 'application'
 }
 
 group = 'uk.nhs.digital.nhsconnect'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
-bootJar {
-	mainClassName = 'uk.nhs.digital.nhsconnect.lab.results.IntegrationAdapterLabResultsApplication'
+application {
+	mainClass.set('uk.nhs.digital.nhsconnect.lab.results.IntegrationAdapterLabResultsApplication')
 }
 
 sourceSets {


### PR DESCRIPTION
Fix the following warnings in the gradle build file:
* New line at the end of the file
* Replace deprecated bootJar `{ mainClassName }` with `application { mainClass... }` 