### PR TITLE
NIAD-825 Dockerize the application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*/**
+!truststore/**
+!src/**
+!activemq/**
+!fake-mesh/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM gradle:jdk11 as cache
+RUN mkdir -p /home/gradle/cache_home
+ENV GRADLE_USER_HOME /home/gradle/cache_home
+COPY build.gradle /home/gradle/src/
+WORKDIR /home/gradle/src
+RUN gradle -b build.gradle clean build -i --stacktrace
+
+FROM gradle:jdk11 AS build
+COPY --from=cache /home/gradle/cache_home /home/gradle/.gradle
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src
+RUN gradle --no-daemon -b build.gradle bootJar -i --stacktrace
+
+FROM adoptopenjdk/openjdk11-openj9:jre
+
+EXPOSE 8080
+
+RUN mkdir /app
+
+COPY --from=build /home/gradle/src/build/libs/*.jar /app/integration-adaptor-lab-results.jar
+
+ENTRYPOINT ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/app/integration-adaptor-lab-results.jar"]

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,0 +1,3 @@
+FROM gradle:jdk11 AS build
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src

--- a/README.md
+++ b/README.md
@@ -11,18 +11,33 @@ The following sections provide the necessary information to develop the Integrat
 * Install [IntelliJ](https://www.jetbrains.com/idea/)
 * Install the [Lombok plugin](https://plugins.jetbrains.com/plugin/6317-lombok)
 
-### Import the integration-adaptor-nhais project
+### Import the integration-adaptor-lab-results project
 
 * Clone this repository
 * Open the cloned `integration-adaptor-lab-results` folder
 * Click pop-up that appears: (import gradle daemon)
 * Verify the project structure
 
+### Start Dependencies
+
+* [rmohr/activemq](https://hub.docker.com/r/rmohr/activemq): ActiveMQ Docker images
+
+[comment]: <> (* [nhsdev/fake-mesh]&#40;https://hub.docker.com/r/nhsdev/fake-mesh&#41;: fake-mesh &#40;mock MESH API server&#41; Docker images)
+
+[comment]: <> (Run `docker-compose up activemq fake-mesh`)
+Run `docker-compose up activemq`
+
 ### Running
 
 **From IntelliJ***
 
 Navigate to: IntegrationAdapterLabResultsApplicationTests -> right click -> Run
+
+**Inside a container**
+
+    export BUILD_TAG=latest
+    docker-compose build lab-results
+    docker-compose up lab-results
 
 ### Running Tests
 
@@ -35,5 +50,3 @@ Navigate to: IntegrationAdapterLabResultsApplicationTests -> right click -> Run
 A separate source folder [src/intTest](./src/intTest) contains integration tests. To run the integration tests use:
 
     ./gradlew integrationTest
-
-

--- a/activemq/Dockerfile
+++ b/activemq/Dockerfile
@@ -1,0 +1,2 @@
+FROM rmohr/activemq:latest
+COPY --chown=activemq:activemq ./activemq.xml $ACTIVEMQ_HOME/conf

--- a/activemq/activemq.xml
+++ b/activemq/activemq.xml
@@ -1,0 +1,151 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- START SNIPPET: example -->
+<beans
+		xmlns="http://www.springframework.org/schema/beans"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+  http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+	<!-- Allows us to use system properties as variables in this configuration file -->
+	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+		<property name="locations">
+			<value>file:${activemq.conf}/credentials.properties</value>
+		</property>
+	</bean>
+
+	<!-- Allows accessing the server log -->
+	<bean id="logQuery" class="io.fabric8.insight.log.log4j.Log4jLogQuery"
+		  lazy-init="false" scope="singleton"
+		  init-method="start" destroy-method="stop">
+	</bean>
+
+	<!--
+		The <broker> element is used to configure the ActiveMQ broker.
+	-->
+	<broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}"
+			schedulerSupport="true">
+
+		<destinationPolicy>
+			<policyMap>
+				<policyEntries>
+					<policyEntry topic=">">
+						<!-- The constantPendingMessageLimitStrategy is used to prevent
+							 slow topic consumers to block producers and affect other consumers
+							 by limiting the number of messages that are retained
+							 For more information, see:
+
+							 http://activemq.apache.org/slow-consumer-handling.html
+
+						-->
+						<pendingMessageLimitStrategy>
+							<constantPendingMessageLimitStrategy limit="1000"/>
+						</pendingMessageLimitStrategy>
+					</policyEntry>
+					<policyEntry queue=">">
+						<deadLetterStrategy>
+							<!--
+							  Use the prefix 'DLQ.' for the destination name, and make
+							  the DLQ a queue rather than a topic
+							-->
+							<individualDeadLetterStrategy queuePrefix="DLQ." useQueueForQueueMessages="true"/>
+						</deadLetterStrategy>
+					</policyEntry>
+				</policyEntries>
+			</policyMap>
+		</destinationPolicy>
+
+
+		<!--
+			The managementContext is used to configure how ActiveMQ is exposed in
+			JMX. By default, ActiveMQ uses the MBean server that is started by
+			the JVM. For more information, see:
+
+			http://activemq.apache.org/jmx.html
+		-->
+		<managementContext>
+			<managementContext createConnector="false"/>
+		</managementContext>
+
+		<!--
+			Configure message persistence for the broker. The default persistence
+			mechanism is the KahaDB store (identified by the kahaDB tag).
+			For more information, see:
+
+			http://activemq.apache.org/persistence.html
+		-->
+		<persistenceAdapter>
+			<kahaDB directory="${activemq.data}/kahadb"/>
+		</persistenceAdapter>
+
+
+		<!--
+		  The systemUsage controls the maximum amount of space the broker will
+		  use before disabling caching and/or slowing down producers. For more information, see:
+		  http://activemq.apache.org/producer-flow-control.html
+		-->
+		<systemUsage>
+			<systemUsage>
+				<memoryUsage>
+					<memoryUsage percentOfJvmHeap="70"/>
+				</memoryUsage>
+				<storeUsage>
+					<storeUsage limit="100 gb"/>
+				</storeUsage>
+				<tempUsage>
+					<tempUsage limit="50 gb"/>
+				</tempUsage>
+			</systemUsage>
+		</systemUsage>
+
+		<!--
+			The transport connectors expose ActiveMQ over a given protocol to
+			clients and other brokers. For more information, see:
+
+			http://activemq.apache.org/configuring-transports.html
+		-->
+		<transportConnectors>
+			<!-- DOS protection, limit concurrent connections to 1000 and frame size to 100MB -->
+			<transportConnector name="openwire"
+								uri="tcp://0.0.0.0:61616?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+			<transportConnector name="amqp"
+								uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+			<transportConnector name="stomp"
+								uri="stomp://0.0.0.0:61613?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+			<transportConnector name="mqtt"
+								uri="mqtt://0.0.0.0:1883?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+			<transportConnector name="ws"
+								uri="ws://0.0.0.0:61614?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+		</transportConnectors>
+
+		<!-- destroy the spring context on shutdown to stop jetty -->
+		<shutdownHooks>
+			<bean xmlns="http://www.springframework.org/schema/beans"
+				  class="org.apache.activemq.hooks.SpringContextHook"/>
+		</shutdownHooks>
+
+	</broker>
+
+	<!--
+		Enable web consoles, REST and Ajax APIs and demos
+		The web consoles requires by default login, you can disable this in the jetty.xml file
+
+		Take a look at ${ACTIVEMQ_HOME}/conf/jetty.xml for more details
+	-->
+	<import resource="jetty.xml"/>
+
+</beans>
+		<!-- END SNIPPET: example -->

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+services:
+  lab-results:
+    ports:
+      - "80:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,124 @@
+version: '3'
+
+services:
+  lab-results:
+    image: local/lab-results:${BUILD_TAG}
+    build:
+      context: .
+      dockerfile: Dockerfile
+    #    ports: See docker-compose.override.yml
+    environment:
+      - LAB_RESULTS_LOGGING_LEVEL=INFO
+      - LAB_RESULTS_OUTBOUND_SERVER_PORT=8080
+      - LAB_RESULTS_AMQP_RETRY_DELAY=100
+      - LAB_RESULTS_AMQP_MAX_RETRIES=3
+      - LAB_RESULTS_AMQP_BROKERS=amqp://activemq:5672
+      - LAB_RESULTS_OUTBOUND_QUEUE_NAME=lab_results_outbound
+      - LAB_RESULTS_SSL_TRUST_STORE_URL=
+      - LAB_RESULTS_SSL_TRUST_STORE_PASSWORD=
+      - LAB_RESULTS_MESH_MAILBOX_ID=gp_mailbox
+      - LAB_RESULTS_MESH_MAILBOX_PASSWORD=password
+      - LAB_RESULTS_MESH_SHARED_KEY=SharedKey
+      - LAB_RESULTS_MESH_HOST=https://fake-mesh:8829/messageexchange/
+      - LAB_RESULTS_MESH_CERT_VALIDATION=false
+      - LAB_RESULTS_MESH_ENDPOINT_CERT=-----BEGIN CERTIFICATE-----
+        MIIFXzCCA0egAwIBAgIJALRbCSor9bEbMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
+        BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
+        aWRnaXRzIFB0eSBMdGQwIBcNMTYwNDIwMTczOTA5WhgPMjIxNjAzMDMxNzM5MDla
+        MEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJ
+        bnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAw
+        ggIKAoICAQDTHtXZykS5dsvFvhMWKB43p79NWJfHgH0sy4fDAQ1fU/lXc7kzR398
+        sIWu67l1Tc9YqhTatPNSR+WPlc7O7bEB+1iLcoMzNFHawHLGOPFv+owjJsY3XMLV
+        rOUPOpzT+ggaieI+FBxx0PIDfleRiTdkAtozC5wKDxEJtrpt4blMMit7VaeTp7dX
+        ryJv1VAq034wjLzLjBI2l9H7Gx+JVCGtrxTxwDZrpoIdkJ7uCxOdO3bwpT2fvR8O
+        RwmefC90q25sabeIodJxu2iqqRawHtaQ7g4WEimK1ed4hUoyOkxwtjfYV26vRXUP
+        vJlTuoh3FhHZw5xAODBt+fMqJFjPlAYfCtMkXVNflu5ObTrQ5iQme40Ugbh3rSNE
+        fQV68D6Qs9Bfs9EWMBx3h8PsLg7WCbaKhcm0oMavHXr12lH/z/nCf+cU+61U1yJ+
+        Bn9g2Fn8iEb7b4J3qpQ+Cxf/pYknrXsgYY4p8j0EkQgBZDoHr7Tgb+koUOcn1InK
+        NQLX2KV7MTe9P7ikn/kbE+HpW5bCL+N2KETV9qlqJ0mUR2H5+eaX+yme2Af0afFZ
+        Z9rb97jzC9Elad3F6NK7Jdr6u3cPKIaU3qbuYDq3MxdtMGjiWyYRzixofpMgUqYm
+        8EEv6GsT+eZNY+rhlyUkEou6upgOkLmZcNsbEM/K+JJm0bW87YoVBwIDAQABo1Aw
+        TjAdBgNVHQ4EFgQUXxJ+6UmJ4cVNqXurwQJeyQALP4YwHwYDVR0jBBgwFoAUXxJ+
+        6UmJ4cVNqXurwQJeyQALP4YwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOC
+        AgEAmrJdePkitQtZmhopjnw11eT0WmvZnZfPDccm8LJ8uevQfHKdM5uruDGeE0r5
+        SbUGuxC08Bs42ZNnqbXsbSzK7piHBfwG95VYC9knfBBg2Gv9EDKSJnr8NXdDyJeF
+        caycrkFeGkdRal3bCfXO3rHQiMtukFG+x/OzD9gjEPEfmbBXC/gOesWJNFmS4doG
+        +A4lAIXEbvDYdlzH/jh9C26t8LWwRirL9Hn6fHQbN4ywDH4n3FRvSElwH/uk/mEv
+        4ksPphrAV760Rxsjy6XM2+IwFs1BrQVkPKT91WirFampmvsKModqhXJPb0SPLdd0
+        G4sfyeiRzbzDjiq4igvD1HLIulPrbkdpLNUOsaSL56xE19FpHjl95OI9leKQeUMd
+        No3A+gh00sBCYZvhHXCPVACQGOke8JeChxBmqWWuOdBXyXyE9iSZtN4SqNhWjGTQ
+        97cqxZ4zgzmvb5FaGyG6ZmlWjCpkwNpbETp6CmqqN4sr//QnY+fc/6k5E3V31JWu
+        lB6mv/JlORiEnDZjP6fO1L7yEvvc1vMlMMDCfNLbU5sdmp3LouR1Yf7uMzGzVL8r
+        MsL1ds0kLcY9oQlduXOumM/bj+0hJTHxc06tr9ilzDAgQ+m48+xLxa6+X27m5pnl
+        W/JNIRmhLoeFNGNh8HvhI2PwOCsFiqT1rrCaUtusTyH0Ggs=
+        -----END CERTIFICATE-----
+      - LAB_RESULTS_MESH_ENDPOINT_PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----
+        MIIJKQIBAAKCAgEA0x7V2cpEuXbLxb4TFigeN6e/TViXx4B9LMuHwwENX1P5V3O5
+        M0d/fLCFruu5dU3PWKoU2rTzUkflj5XOzu2xAftYi3KDMzRR2sByxjjxb/qMIybG
+        N1zC1azlDzqc0/oIGoniPhQccdDyA35XkYk3ZALaMwucCg8RCba6beG5TDIre1Wn
+        k6e3V68ib9VQKtN+MIy8y4wSNpfR+xsfiVQhra8U8cA2a6aCHZCe7gsTnTt28KU9
+        n70fDkcJnnwvdKtubGm3iKHScbtoqqkWsB7WkO4OFhIpitXneIVKMjpMcLY32Fdu
+        r0V1D7yZU7qIdxYR2cOcQDgwbfnzKiRYz5QGHwrTJF1TX5buTm060OYkJnuNFIG4
+        d60jRH0FevA+kLPQX7PRFjAcd4fD7C4O1gm2ioXJtKDGrx169dpR/8/5wn/nFPut
+        VNcifgZ/YNhZ/IhG+2+Cd6qUPgsX/6WJJ617IGGOKfI9BJEIAWQ6B6+04G/pKFDn
+        J9SJyjUC19ilezE3vT+4pJ/5GxPh6VuWwi/jdihE1fapaidJlEdh+fnml/spntgH
+        9GnxWWfa2/e48wvRJWndxejSuyXa+rt3DyiGlN6m7mA6tzMXbTBo4lsmEc4saH6T
+        IFKmJvBBL+hrE/nmTWPq4ZclJBKLurqYDpC5mXDbGxDPyviSZtG1vO2KFQcCAwEA
+        AQKCAgEAqDsXD6BFWUCXqjAHR42aXqEWKM0izT/O/2YD/dkVzdO9iflWJ82egj6r
+        mDKQqy/gvPdy/MBacEOIYv1uOahgd4LREPWkJKZZX6YhD2GKyr9s8gnQw4bwXpKS
+        SKtdEvFXicY7+VnPPMbSQwRnRTqBX/mB5FEo+z78RbBNKIhJPrVvvq0HhvqLd5zA
+        JTtm0WmMUaWkP9KTJNuf4KfBXo4i9CLi3q1a8DdT0blPW8KJ063x3lreGy7500e6
+        G4c7zY1ZxZwMOx0v857yDaQFxzwboIuBwAajAdXnyDr2X8Xi6aHaKFOriJEhcfPI
+        flbSrYpxmQRtuyLLPKeDJB6ogmii4qCVcnotw9co1yz3nRXbPOaTw+pDg7ZZveDn
+        02Ip+ayQFrQVzS9aZmZr4eR+Hh6681Ujng3Zrdp03rUXpQ1opyjN1K4rExIRjEiK
+        Q9cP/0Y3LF5mpwfm0+SxdbZ6FAa57N5quSobNaWGTb1SYF1BtPf/B6s2RfUZOjhg
+        pwKBF4fL/eHnCfqV8dWlOBs48TwdYrLxurOEGkqFicGdKGO8ayERHpmFD+V7YNbd
+        PrwyoUbK9Jh8ApslRLTOBcDz+3Cx1oogDMHXkMy7FzvG6s54RgA0SS+SzsS5yMDP
+        XF7iymVzdwDTeaA0y2lPgHD/nnVfwzZttXiRvLILOKTemp+NrPECggEBAPU6oyJO
+        +zYeBoDs8aT0YU0OfyfUJa3ZKvIp0AZ8nKU/6otlPu/2gtoHrJfPo0XssczEs3py
+        wMSX+WxNASKCVRtbqRWVJa/8tRf3YfDeUUrS1aWyD1UEQG6RwG+ACB4W0l+RRVhS
+        YBgDyjivPy0OK2hm6T8ctoMWlVv76uhwWkfkFsIzLfQ8HEeySjMngxPW69lgw9/v
+        Sl6fiMeWdsDtoHGqHqluMBLxvBuaLdaFpiNSP+npPweRkii01DWlMojpPWYDVpo5
+        fx62qBUhk+SineYmzKfmUT972T4EHvK0WGSm3BKQB1K0H9wMlBJXXVaQMl0fQ/bw
+        6AAwOugU/fqycX8CggEBANxkrhOMrc5x2Juvn6rzpdG1w29qKUWInpS8tvKdJ4fd
+        5iT+A4y4a6rHLGxFQRWePNJ+6uqmy/zwr74BLineDc9slc51PRz/T9S6odAHDWIP
+        X4qho8xfzzN8gSnjrc3TGlpnQAA5u8I/nggfzCUDBYNBmYai7mbuD2ckpRGKf2dr
+        dNA77azK5n7HBJqS4dkCphnoSwZicmtsT94Ol6AbmIDkyyLfJ0uBuSPtjZj0rySu
+        li/0oR6tilVgphvPKeuxcaD4YmA7S6MpIv8Kvl/8960Wh1qEDTDrAr7t7TU6mz9z
+        5vc2rFix19WFDyeCfse6Igfcgg3Pge9l/yWHoVglkHkCggEAFtkBvf6R1Tby8Cwj
+        T3UdY6qIGlPfttTW9X0DzrbpeVP9LEOgm4biJiI06GgGFEu7PRLOjggHAcoPCRIb
+        mvV9rHDbzhD5U+49iSAZVfHArTH7idaPKyKcRjD6Nuk82GDT9Od6CIKURWiE/McH
+        IdGCJdYAwUqRjqEaBVnxRvrAzpXnsOxHycuX7u4jj6SMx9psWvJzDXgj+7Dtc3sH
+        UW5SVoS9GpgTjpBLMF8rCiOlmQDex5JdtvzPG0/NvbnIfY0NlWWWOgRFXb0y59Ub
+        DGBCSeEvjC0fQMTvNqH3qDE5UxdgxbH5nLD/jub1HMha/+eraZWyJV3In8vekSTz
+        jNn3TQKCAQByWtcsE6GXbeD7nxvU4wlWD97xL39ssd++w1CWAE8jo1KoPRjwajyL
+        Zz84ipKjufBLNEmGKbfMbcJyb0BZvvshdnEgqBpmsl7kvVX6j7409E8ZqpdIEyp6
+        x45pgtaK5o9U+x/tPgebWdEQ3Bbb2X6BxYb4og/bXoildxEjUd6bddkttvqy3rDM
+        dU2BOtdu933iEXLkRC6kaJXkXWP1UnxF3PE+DdXgytWau8bt53/9I42QInl7ZoZR
+        mI13/nz865xO7rJ0xi+P4GdlOFjhi2uj5v2iTMRfboGFOgULynYFbYkZGshAWT7p
+        bloXoRFRZtYDiDn/Gn2MDztdaMuh5hPZAoIBAQDEASV+dXBNZOIxQ5IQVn6xMOTs
+        kKiA539B0lD2CDJQI7UXeat1sJXHZx8QVodY1VwQCJW8u4XLxphgC1Wx9+EjXek8
+        +C8OxuXZamXgRaGeCFn3Ev3XsQnRiDVJJZ34JuDBP+hcGIj4JPHQE9qEsPKRBkyJ
+        yIBNWf7N1eRRn5h4cVMolnvbulEppXYTlKDKqYgrNecIESiWd8WHPeudkWLmDcfy
+        +yLvICQmVjHWsNWD3uuT3gEGdeKDIzEnovXUmqhQE7N/YDupTv5hkh8hMKl12XGs
+        3WJ4bVSmp3MOQ2EF4zrAl4fXEd4lS3JxKtzbHFbSogAmPFnuP8wIDWTDgfEq
+        -----END RSA PRIVATE KEY-----
+      # check mailbox name
+      - LAB_RESULTS_MESH_POLLING_CYCLE_MINIMUM_INTERVAL_IN_SECONDS=300
+      - LAB_RESULTS_MESH_CLIENT_WAKEUP_INTERVAL_IN_MILLISECONDS=60000
+      - LAB_RESULTS_SCHEDULER_ENABLED=true
+
+  activemq:
+    build:
+      context: ./activemq
+    ports:
+      - "8161:8161"
+      - "5672:5672"
+
+#  fake-mesh:
+#    image: nhsdev/fake-mesh:0.2.0
+#    ports:
+#      - "8829:8829"
+  # Enable if you need to inspect the fake-mesh database for any reason
+  #    volumes:
+  #      - ./fake_mesh_dir:/tmp/fake_mesh_dir


### PR DESCRIPTION
Prepare docker configuration, using https://github.com/nhsconnect/integration-adaptor-nhais as a reference.

MongoDB is not being used, so that was stripped out.
MESH client will be handled in NIAD-828, so that was stripped out.
This project will not use a responder mock, so that was stripped out.

Co-authored with @antonlebedjko 