### PR TITLE
NIAD-859: Switch FHIR dependencies from R4 to DSTU3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,223 @@
+String tfProject     = "nia"
+String tfEnvironment = "build1" // change for ptl, vp goes here
+String tfComponent   = "lab-results"  // this defines the application - nhais, mhs etc
+
+pipeline {
+    agent{
+        label 'jenkins-workers'
+    }
+
+    options {
+        timestamps()
+        buildDiscarder(logRotator(numToKeepStr: "10")) // keep only last 10 builds
+    }
+
+    environment {
+        BUILD_TAG = sh label: 'Generating build tag', returnStdout: true, script: 'python3 pipeline/scripts/tag.py ${GIT_BRANCH} ${BUILD_NUMBER} ${GIT_COMMIT}'
+        BUILD_TAG_LOWER = sh label: 'Lowercase build tag', returnStdout: true, script: "echo -n ${BUILD_TAG} | tr '[:upper:]' '[:lower:]'"
+        ENVIRONMENT_ID = "lab-results-build"
+        // Need AWS first of all. Change it later
+        ECR_REPO_DIR = "lab-results"
+        DOCKER_IMAGE = "${DOCKER_REGISTRY}/${ECR_REPO_DIR}:${BUILD_TAG}"
+    }
+
+    stages {
+        stage('Build and Test Locally') {
+            stages {
+                stage('Run Tests') {
+                    steps {
+                        script {
+                            sh label: 'Create logs directory', script: 'mkdir -p logs build'
+                            if (sh(label: 'Build lab-results', script: 'docker build -t local/lab-results-tests:${BUILD_TAG} -f Dockerfile.tests .', returnStatus: true) != 0) {error("Failed to build docker image for tests")}
+                            if (sh(label: 'Running tests', script: 'docker run -v /var/run/docker.sock:/var/run/docker.sock --name lab-results-tests local/lab-results-tests:${BUILD_TAG} gradle check -i', returnStatus: true) != 0) {error("Some tests failed, check the logs")}
+                        }
+                    }
+                    post {
+                        always {
+                            sh "docker cp lab-results-tests:/home/gradle/src/build ."
+                            junit '**/build/test-results/**/*.xml'
+                            step([
+                                $class : 'JacocoPublisher',
+                                execPattern : '**/build/jacoco/*.exec',
+                                classPattern : '**/build/classes/java',
+                                sourcePattern : 'src/main/java',
+                                exclusionPattern : '**/*Test.class'
+                            ])
+                            sh "rm -rf build"
+                        }
+                    }
+                }
+                stage('Build Docker Images') {
+                    steps {
+                        script {
+                            sh label: 'Running docker build', script: 'docker build -t ${DOCKER_IMAGE} .'
+                        }
+                    }
+                }
+                stage('Push image') {
+                    when {
+                        expression { currentBuild.resultIsBetterOrEqualTo('SUCCESS') }
+                    }
+                    steps {
+                        script {
+                            if (ecrLogin(TF_STATE_BUCKET_REGION) != 0 )  { error("Docker login to ECR failed") }
+                            String dockerPushCommand = "docker push ${DOCKER_IMAGE}"
+                            // Change echo to be an error once the AWS has been set up
+                            if (sh (label: "Pushing image", script: dockerPushCommand, returnStatus: true) !=0) { echo("Docker push image failed") }
+                        }
+                    }
+                }
+            }
+            post {
+                always {
+                    sh label: 'Copy lab-results container logs', script: 'docker-compose logs lab-results > logs/lab-results.log'
+                    sh label: 'Copy activemq logs', script: 'docker-compose logs activemq > logs/inbound.log'
+                    archiveArtifacts artifacts: 'logs/*.log', fingerprint: true
+                    sh label: 'Stopping containers', script: 'docker-compose down -v'
+                }
+            }
+        }
+        stage('Deploy and Integration Test') {
+            when {
+                expression { currentBuild.resultIsBetterOrEqualTo('SUCCESS') }
+            }
+            options {
+              lock("${tfProject}-${tfEnvironment}-${tfComponent}")
+            }
+            stages {
+                stage('Deploy using Terraform') {
+                    steps {
+                        script {
+                            String tfCodeBranch  = "develop"
+                            String tfCodeRepo    = "https://github.com/nhsconnect/integration-adaptors"
+                            String tfRegion      = "${TF_STATE_BUCKET_REGION}"
+                            Map<String,String> tfVariables = ["${tfComponent}_build_id": BUILD_TAG]
+                            dir ("integration-adaptors") {
+                              // Clone repository with terraform
+                              git (branch: tfCodeBranch, url: tfCodeRepo)
+                              dir ("terraform/aws") {
+                                // Run TF Init
+                                if (terraformInit(TF_STATE_BUCKET, tfProject, tfEnvironment, tfComponent, tfRegion) !=0) { error("Terraform init failed")}
+
+                                // Run TF Plan
+                                // Change echo to be error once the AWS has been set up
+                                if (terraform('plan', TF_STATE_BUCKET, tfProject, tfEnvironment, tfComponent, tfRegion, tfVariables) !=0 ) { echo("Terraform Plan failed")}
+
+                                //Run TF Apply
+                                // Change echo to be error once the AWS has been set up
+                                if (terraform('apply', TF_STATE_BUCKET, tfProject, tfEnvironment, tfComponent, tfRegion, tfVariables) !=0 ) { echo("Terraform Apply failed")}
+                              } // dir terraform/aws
+                            } // dir integration-adaptors
+                        } //script
+                    } //steps
+                } //stage
+            } //stages
+        }
+
+
+    }
+    post {
+        always {
+            sh label: 'Stopping containers', script: 'docker-compose down -v'
+            sh label: 'Remove all unused images not just dangling ones', script:'docker system prune --force'
+            sh 'docker image rm -f $(docker images "*/*:*${BUILD_TAG}" -q) $(docker images "*/*/*:*${BUILD_TAG}" -q) || true'
+        }
+    }
+}
+
+int terraformInit(String tfStateBucket, String project, String environment, String component, String region) {
+  println("Terraform Init for Environment: ${environment} Component: ${component} in region: ${region} using bucket: ${tfStateBucket}")
+  String command = "terraform init -backend-config='bucket=${tfStateBucket}' -backend-config='region=${region}' -backend-config='key=${project}-${environment}-${component}.tfstate' -input=false -no-color"
+  dir("components/${component}") {
+    return( sh( label: "Terraform Init", script: command, returnStatus: true))
+  } // dir
+} // int TerraformInit
+
+int terraform(String action, String tfStateBucket, String project, String environment, String component, String region, Map<String, String> variables=[:], List<String> parameters=[]) {
+    println("Running Terraform ${action} in region ${region} with: \n Project: ${project} \n Environment: ${environment} \n Component: ${component}")
+    variablesMap = variables
+    variablesMap.put('region',region)
+    variablesMap.put('project', project)
+    variablesMap.put('environment', environment)
+    variablesMap.put('tf_state_bucket',tfStateBucket)
+    parametersList = parameters
+    parametersList.add("-no-color")
+
+    // Get the secret variables for global
+    String secretsFile = "etc/secrets.tfvars"
+    writeVariablesToFile(secretsFile,getAllSecretsForEnvironment(environment,"nia",region))
+
+    List<String> variableFilesList = [
+      "-var-file=../../etc/global.tfvars",
+      "-var-file=../../etc/${region}_${environment}.tfvars",
+      "-var-file=../../${secretsFile}"
+    ]
+    if (action == "apply"|| action == "destroy") {parametersList.add("-auto-approve")}
+    List<String> variablesList=variablesMap.collect { key, value -> "-var ${key}=${value}" }
+    String command = "terraform ${action} ${variableFilesList.join(" ")} ${parametersList.join(" ")} ${variablesList.join(" ")} "
+    dir("components/${component}") {
+      return sh(label:"Terraform: "+action, script: command, returnStatus: true)
+    } // dir
+} // int Terraform
+
+int ecrLogin(String aws_region) {
+    String ecrCommand = "aws ecr get-login --region ${aws_region}"
+    String dockerLogin = sh (label: "Getting Docker login from ECR", script: ecrCommand, returnStdout: true).replace("-e none","") // some parameters that AWS provides and docker does not recognize
+    return sh(label: "Logging in with Docker", script: dockerLogin, returnStatus: true)
+}
+
+// Retrieving Secrets from AWS Secrets
+String getSecretValue(String secretName, String region) {
+  String awsCommand = "aws secretsmanager get-secret-value --region ${region} --secret-id ${secretName} --query SecretString --output text"
+  return sh(script: awsCommand, returnStdout: true).trim()
+}
+
+Map<String,Object> decodeSecretKeyValue(String rawSecret) {
+  List<String> secretsSplit = rawSecret.replace("{","").replace("}","").split(",")
+  Map<String,Object> secretsDecoded = [:]
+  secretsSplit.each {
+    String key = it.split(":")[0].trim().replace("\"","")
+    Object value = it.split(":")[1]
+    secretsDecoded.put(key,value)
+  }
+  return secretsDecoded
+}
+
+List<String> getSecretsByPrefix(String prefix, String region) {
+  String awsCommand = "aws secretsmanager list-secrets --region ${region} --query SecretList[].Name --output text"
+  List<String> awsReturnValue = sh(script: awsCommand, returnStdout: true).split()
+  return awsReturnValue.findAll { it.startsWith(prefix) }
+}
+
+Map<String,Object> getAllSecretsForEnvironment(String environment, String secretsPrefix, String region) {
+  List<String> globalSecrets = getSecretsByPrefix("${secretsPrefix}-global",region)
+  println "global secrets:" + globalSecrets
+  List<String> environmentSecrets = getSecretsByPrefix("${secretsPrefix}-${environment}",region)
+  println "env secrets:" + environmentSecrets
+  Map<String,Object> secretsMerged = [:]
+  globalSecrets.each {
+    String rawSecret = getSecretValue(it,region)
+    if (it.contains("-kvp")) {
+      secretsMerged << decodeSecretKeyValue(rawSecret)
+    } else {
+      secretsMerged.put(it.replace("${secretsPrefix}-global-",""),rawSecret)
+    }
+  }
+  environmentSecrets.each {
+    String rawSecret = getSecretValue(it,region)
+    if (it.contains("-kvp")) {
+      secretsMerged << decodeSecretKeyValue(rawSecret)
+    } else {
+      secretsMerged.put(it.replace("${secretsPrefix}-${environment}-",""),rawSecret)
+    }
+  }
+  return secretsMerged
+}
+
+void writeVariablesToFile(String fileName, Map<String,Object> variablesMap) {
+  List<String> variablesList=variablesMap.collect { key, value -> "${key} = ${value}" }
+  sh (script: "touch ${fileName} && echo '\n' > ${fileName}")
+  variablesList.each {
+    sh (script: "echo '${it}' >> ${fileName}")
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 	implementation 'com.heroku.sdk:env-keystore:1.1.6'
 
 	implementation 'ca.uhn.hapi.fhir:hapi-fhir-base:5.2.0'
-	implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-r4:5.2.0'
+	implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:5.2.0'
 
 	implementation 'org.projectlombok:lombok'
 	testImplementation 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
 	id 'java'
 	id 'io.freefair.lombok' version '5.3.0'
 	id 'application'
+	id 'jacoco'
 }
 
 group = 'uk.nhs.digital.nhsconnect'
@@ -71,6 +72,10 @@ lombok {
 
 test {
 	useJUnitPlatform()
+}
+
+jacocoTestReport {
+	dependsOn test // tests are required to run before generating the report
 }
 
 task integrationTest(type: Test) {

--- a/pipeline/scripts/tag.py
+++ b/pipeline/scripts/tag.py
@@ -1,0 +1,38 @@
+"""A module that provides functions to generate tags suitable for identifying specific CI/CD builds."""
+
+import argparse
+
+
+def generate_tag(branch_name: str, build_id: str, git_hash: str) -> str:
+    """Generate a build tag from the provided values.
+    :param branch_name: The name of the branch this build is being performed for.
+    :param build_id: The identifier of the build being performed.
+    :param git_hash: Git hash of the commit used.
+    :return: A string that represents the build being performed.
+    """
+    clean_branch_name = _clean_tag_element(branch_name)
+    clean_build_id = _clean_tag_element(build_id)
+
+    tag = "-".join([clean_branch_name, clean_build_id, git_hash[:7]])
+    return tag
+
+
+def _clean_tag_element(tag_element: str) -> str:
+    clean_tag_element = tag_element.replace("/", "-")
+    return clean_tag_element
+
+
+def _parse_arguments():
+    parser = argparse.ArgumentParser(description="Generates a tag suitable for identifying a specific CI/CD build.")
+
+    parser.add_argument("branch_name", help="The name of the branch this build is being performed for.")
+    parser.add_argument("build_id", help="The identifier of the build being performed.")
+    parser.add_argument("git_hash", help="The git hash of commit used.")
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_arguments()
+
+    print(generate_tag(args.branch_name, args.build_id, args.git_hash), end="")

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/rest/exception/BadRequestException.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/rest/exception/BadRequestException.java
@@ -1,7 +1,7 @@
 package uk.nhs.digital.nhsconnect.lab.results.rest.exception;
 
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
-import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.dstu3.model.OperationOutcome;
 import uk.nhs.digital.nhsconnect.lab.results.utils.OperationOutcomeUtils;
 
 public abstract class BadRequestException extends LabResultsBaseException {

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/utils/OperationOutcomeUtils.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/utils/OperationOutcomeUtils.java
@@ -1,7 +1,7 @@
 package uk.nhs.digital.nhsconnect.lab.results.utils;
 
-import org.hl7.fhir.r4.model.CodeableConcept;
-import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.dstu3.model.CodeableConcept;
+import org.hl7.fhir.dstu3.model.OperationOutcome;
 
 public class OperationOutcomeUtils {
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/IntegrationAdapterLabResultsApplicationTests.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/IntegrationAdapterLabResultsApplicationTests.java
@@ -1,11 +1,9 @@
 package uk.nhs.digital.nhsconnect.lab.results;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-@Disabled
 class IntegrationAdapterLabResultsApplicationTests {
 
     @Test

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/IntegrationAdapterLabResultsApplicationTests.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/IntegrationAdapterLabResultsApplicationTests.java
@@ -8,8 +8,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @Disabled
 class IntegrationAdapterLabResultsApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/IntegrationAdapterLabResultsApplicationTests.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/IntegrationAdapterLabResultsApplicationTests.java
@@ -1,9 +1,11 @@
 package uk.nhs.digital.nhsconnect.lab.results;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@Disabled
 class IntegrationAdapterLabResultsApplicationTests {
 
 	@Test

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/utils/OperationOutcomeUtilsTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/utils/OperationOutcomeUtilsTest.java
@@ -1,6 +1,6 @@
 package uk.nhs.digital.nhsconnect.lab.results.utils;
 
-import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.dstu3.model.OperationOutcome;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -10,7 +10,7 @@ labresults:
     username: ${LAB_RESULTS_MONGO_USERNAME:}
     password: ${LAB_RESULTS_MONGO_PASSWORD:}
     options: ${LAB_RESULTS_MONGO_OPTIONS:}
-    autoIndexCreation: true
+    autoIndexCreation: false
     ttl: ${LAB_RESULTS_MONGO_TTL:P30D}
     cosmosDbEnabled: ${LAB_RESULTS_COSMOS_DB_ENABLED:false}
   mesh:


### PR DESCRIPTION
When porting classes over from the NHAIS project we used the same FHIR dependencies, but our specific adaptor needs different ones.

Fortunately, the libraries have some duplicated classes and fixing the broken classes was as simple as changing `r4` to `dstu3` in import statements.

Also had to disable the `IntegrationAdapterLabResultsApplicationTests` class because it tries to load the context, which requires mongo to be running.