### PR TITLE
Use a factory to create Interchange objects

### DIFF
--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/message/InterchangeFactory.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/message/InterchangeFactory.java
@@ -1,0 +1,13 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact.message;
+
+import org.springframework.stereotype.Component;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Interchange;
+
+import java.util.List;
+
+@Component
+public class InterchangeFactory {
+    public Interchange createInterchange(List<String> edifactSegments) {
+        return new Interchange(edifactSegments);
+    }
+}

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/EdifactParserTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/EdifactParserTest.java
@@ -62,14 +62,10 @@ class EdifactParserTest {
     @InjectMocks
     private EdifactParser edifactParser;
 
-    @BeforeEach
-    void trainInterchangeFactory() {
-        when(interchangeFactory.createInterchange(any()))
-                .thenReturn(interchange);
-    }
-
     @Test
     void testParseCreatesInterchangeWithSameMessage() {
+        when(interchangeFactory.createInterchange(any())).thenReturn(interchange);
+
         Interchange interchange = edifactParser.parse(String.join("\n", SAMPLE_EDIFACT));
 
         assertNotNull(interchange);

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/EdifactParserTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/EdifactParserTest.java
@@ -1,48 +1,86 @@
 package uk.nhs.digital.nhsconnect.lab.results.inbound;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Interchange;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.InterchangeFactory;
 
-public class EdifactParserTest {
+import java.util.List;
 
-    private final String edifactString = "UNB+UNOA:2+TES5+XX11+020114:1619+00000003'\n" +
-            "UNH+00000004+FHSREG:0:1:FH:FHS001'\n" +
-            "BGM+++507'\n" +
-            "NAD+FHS+XX1:954'\n" +
-            "DTM+137:199201141619:203'\n" +
-            "RFF+950:F4'\n" +
-            "RFF+TN:18'\n" +
-            "S01+1'\n" +
-            "NAD+GP+2750922,295:900'\n" +
-            "NAD+RIC+RT:956'\n" +
-            "QTY+951:6'\n" +
-            "QTY+952:3'\n" +
-            "HEA+ACD+A:ZZZ'\n" +
-            "HEA+ATP+2:ZZZ'\n" +
-            "HEA+BM+S:ZZZ'\n" +
-            "HEA+DM+Y:ZZZ'\n" +
-            "DTM+956:19920114:102'\n" +
-            "LOC+950+GLASGOW'\n" +
-            "FTX+RGI+++BABY AT THE REYNOLDS-THORPE CENTRE'\n" +
-            "S02+2'\n" +
-            "PNA+PAT+NHS123:OPI+++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA'\n" +
-            "DTM+329:19911209:102'\n" +
-            "PDI+2'\n" +
-            "NAD+PAT++??:26 FARMSIDE CLOSE:ST PAULS CRAY:ORPINGTON:KENT+++++BR6  7ET'\n" +
-            "UNT+24+00000004'\n" +
-            "UNZ+1+00000003'";
+@ExtendWith(MockitoExtension.class)
+class EdifactParserTest {
+    private static final String EDIFACT_HEADER = "UNB+UNOA:2+TES5+XX11+020114:1619+00000003";
+    private static final String EDIFACT_TRAILER = "UNZ+1+00000003";
 
-    @Test
-    void testMessageHeader() {
-        Interchange interchange = new EdifactParser().parse(edifactString);
-        assertEquals("UNOA:2+TES5+XX11+020114:1619+00000003", interchange.getInterchangeHeader().getValue());
+    private static final List<String> SAMPLE_EDIFACT = List.of(
+            EDIFACT_HEADER + "'",
+            "UNH+00000004+FHSREG:0:1:FH:FHS001'",
+            "BGM+++507'",
+            "NAD+FHS+XX1:954'",
+            "DTM+137:199201141619:203'",
+            "RFF+950:F4'",
+            "RFF+TN:18'",
+            "S01+1'",
+            "NAD+GP+2750922,295:900'",
+            "NAD+RIC+RT:956'",
+            "QTY+951:6'",
+            "QTY+952:3'",
+            "HEA+ACD+A:ZZZ'",
+            "HEA+ATP+2:ZZZ'",
+            "HEA+BM+S:ZZZ'",
+            "HEA+DM+Y:ZZZ'",
+            "DTM+956:19920114:102'",
+            "LOC+950+GLASGOW'",
+            "FTX+RGI+++BABY AT THE REYNOLDS-THORPE CENTRE'",
+            "S02+2'",
+            "PNA+PAT+NHS123:OPI+++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA'",
+            "DTM+329:19911209:102'",
+            "PDI+2'",
+            "NAD+PAT++??:26 FARMSIDE CLOSE:ST PAULS CRAY:ORPINGTON:KENT+++++BR6  7ET'",
+            "UNT+24+00000004'",
+            EDIFACT_TRAILER + "'"
+    );
+
+    @Mock
+    private InterchangeFactory interchangeFactory;
+
+    @Mock
+    private Interchange interchange;
+
+    @InjectMocks
+    private EdifactParser edifactParser;
+
+    @BeforeEach
+    void trainInterchangeFactory() {
+        when(interchangeFactory.createInterchange(any()))
+                .thenReturn(interchange);
     }
 
     @Test
-    void testMessageTrailer() {
-        Interchange interchange = new EdifactParser().parse(edifactString);
-        assertEquals("1+00000003", interchange.getInterchangeTrailer().getValue());
+    void testParseCreatesInterchangeWithSameMessage() {
+        Interchange interchange = edifactParser.parse(String.join("\n", SAMPLE_EDIFACT));
+
+        assertNotNull(interchange);
+
+        // trailing empty string because we split by apostrophe and there's a trailing apostrophe
+        verify(interchangeFactory).createInterchange(List.of(EDIFACT_HEADER, EDIFACT_TRAILER, ""));
+    }
+
+    @Test
+    void testParsePropagatesExceptionsFromInvalidContent() {
+        assertThrows(IndexOutOfBoundsException.class, () -> edifactParser.parse("invalid edifact"));
     }
 
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/message/InterchangeFactoryTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/message/InterchangeFactoryTest.java
@@ -1,0 +1,25 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact.message;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Interchange;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InterchangeFactoryTest {
+    private InterchangeFactory interchangeFactory;
+
+    @BeforeEach
+    void setUp() {
+        this.interchangeFactory = new InterchangeFactory();
+    }
+
+    @Test
+    void testCreate() {
+        final List<String> strings = List.of("foo", "bar");
+        Interchange result = interchangeFactory.createInterchange(strings);
+        assertEquals(strings, result.getEdifactSegments());
+    }
+}


### PR DESCRIPTION
Testing of the EdifactParser was rather more complicated
than it needed to be, because it was constructing
Interchange objects itself (new). By deferring construction
to an injected factory, we can mock the result and have
better control over the real responsibilities of the
EdifactParser class.