### PR TITLE
NIAD-858: Add correlation id and message id in log entries

### DIFF
--- a/src/intTest/resources/application.yml
+++ b/src/intTest/resources/application.yml
@@ -4,6 +4,8 @@ server:
 logging:
   level:
     uk.nhs.digital.nhsconnect.lab.results: ${LAB_RESULTS_LOGGING_LEVEL:DEBUG}
+  pattern:
+    console: "-%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} ConversationId=%X{ConversationId} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"
 
 labresults:
   amqp:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,8 @@ server:
 logging:
   level:
     uk.nhs.digital.nhsconnect.lab.results: ${LAB_RESULTS_LOGGING_LEVEL:INFO}
+  pattern:
+    console: "-%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} ConversationId=%X{ConversationId} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"
 
 spring:
   jms:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,6 +1,10 @@
 server:
   port: 8080
 
+logging:
+  pattern:
+    console: "-%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} ConversationId=%X{ConversationId} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"
+
 labresults:
   amqp:
     brokers: ${LAB_RESULTS_AMQP_BROKERS:amqp://localhost:5672}


### PR DESCRIPTION
https://gpitbjss.atlassian.net/browse/NIAD-858

- Updated test and intTest directories application.yml files to log the conversationId
- Verified that we already logging the messageId's when putting message on inbound queue or picking one from
- Verified that the existing ConversationIdService works fine and now every log entry created contains the ConversationId
![conversationId in practise](https://user-images.githubusercontent.com/36967438/105969404-205d5500-6080-11eb-95bc-9b7a8bda1acd.png)
