### PR TITLE
NIAD-1007: Add SG1 segment code to build segment objects from EDIFACT strings.

### DIFF
--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/HealthcareRegistrationIdentificationCode.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/HealthcareRegistrationIdentificationCode.java
@@ -1,0 +1,25 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum HealthcareRegistrationIdentificationCode {
+    GP("900", "National GP"),
+    GP_PRACTICE("901", "National GP Practice"),
+    CONSULTANT("902", "National Consultant");
+
+    private final String code;
+    private final String description;
+
+    public static HealthcareRegistrationIdentificationCode fromCode(@NonNull String code) {
+        return Arrays.stream(HealthcareRegistrationIdentificationCode.values())
+                .filter(c -> code.equals(c.getCode()))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PerformingOrganisationNameAndAddress.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PerformingOrganisationNameAndAddress.java
@@ -1,0 +1,62 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.EdifactValidationException;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.Split;
+
+/**
+ * Example: NAD+SLA+++ST JAMES?'S UNIVERSITY HOSPITAL'
+ */
+@Getter
+@Setter
+@Builder
+@RequiredArgsConstructor
+public class PerformingOrganisationNameAndAddress extends Segment {
+
+    private static final String KEY = "NAD";
+    private static final String QUALIFIER = "SLA";
+    private static final String KEY_QUALIFIER = KEY + "+" + QUALIFIER;
+    private static final int PERFORMING_ORGANISATION_NAME_INDEX_IN_EDIFACT_STRING = 4;
+
+    @NonNull
+    private final String performingOrganisationName;
+
+    public static PerformingOrganisationNameAndAddress fromString(String edifactString) {
+        if (!edifactString.startsWith(PerformingOrganisationNameAndAddress.KEY_QUALIFIER)) {
+            throw new IllegalArgumentException(
+                "Can't create " + PerformingOrganisationNameAndAddress.class.getSimpleName() + " from " + edifactString
+            );
+        }
+
+        String[] keySplit = Split.byPlus(edifactString);
+        String performingOrganisationName = keySplit[PERFORMING_ORGANISATION_NAME_INDEX_IN_EDIFACT_STRING];
+
+        return new PerformingOrganisationNameAndAddress(performingOrganisationName);
+    }
+
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    @Override
+    public String getValue() {
+        return QUALIFIER + "+++" + performingOrganisationName;
+    }
+
+    @Override
+    protected void validateStateful() throws EdifactValidationException {
+
+    }
+
+    @Override
+    public void preValidate() throws EdifactValidationException {
+        if (performingOrganisationName.isBlank()) {
+            throw new EdifactValidationException(getKey() + ": Attribute performingOrganisationName is required");
+        }
+    }
+}

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RequesterNameAndAddress.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RequesterNameAndAddress.java
@@ -1,0 +1,74 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.EdifactValidationException;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.Split;
+
+/**
+ * Example: NAD+PO+G3380314:900++SCOTT'
+ */
+@Getter
+@Setter
+@Builder
+@RequiredArgsConstructor
+public class RequesterNameAndAddress extends Segment {
+
+    private static final String KEY = "NAD";
+    private static final String QUALIFIER = "PO";
+    private static final String KEY_QUALIFIER = KEY + "+" + QUALIFIER;
+    private static final int REQUESTER_NAME_INDEX_IN_EDIFACT_STRING = 4;
+
+    @NonNull
+    private final String identifier;
+    @NonNull
+    private final HealthcareRegistrationIdentificationCode healthcareRegistrationIdentificationCode;
+    @NonNull
+    private final String requesterName;
+
+    public static RequesterNameAndAddress fromString(String edifactString) {
+        if (!edifactString.startsWith(RequesterNameAndAddress.KEY_QUALIFIER)) {
+            throw new IllegalArgumentException("Can't create " + RequesterNameAndAddress.class.getSimpleName() + " from " + edifactString);
+        }
+
+        String[] keySplit = Split.byPlus(edifactString);
+        String identifier = Split.byColon(keySplit[2])[0];
+        String code = Split.byColon(keySplit[2])[1];
+        String requesterName = keySplit[REQUESTER_NAME_INDEX_IN_EDIFACT_STRING];
+
+        return new RequesterNameAndAddress(identifier, HealthcareRegistrationIdentificationCode.fromCode(code), requesterName);
+    }
+
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    @Override
+    public String getValue() {
+        return QUALIFIER + "+" + identifier + ":" + healthcareRegistrationIdentificationCode.getCode() + "++" + requesterName;
+    }
+
+    @Override
+    protected void validateStateful() throws EdifactValidationException {
+
+    }
+
+    @Override
+    public void preValidate() throws EdifactValidationException {
+        if (identifier.isBlank()) {
+            throw new EdifactValidationException(getKey() + ": Attribute identifier is required");
+        }
+
+        if (healthcareRegistrationIdentificationCode.getCode().isBlank()) {
+            throw new EdifactValidationException(getKey() + ": Attribute code in healthcareRegistrationIdentificationCode is required");
+        }
+
+        if (requesterName.isBlank()) {
+            throw new EdifactValidationException(getKey() + ": Attribute requesterName is required");
+        }
+    }
+}

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ServiceProvider.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ServiceProvider.java
@@ -1,0 +1,57 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.EdifactValidationException;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.Split;
+
+/**
+ * Example: SPR+ORG'
+ */
+@Getter
+@Setter
+@Builder
+@RequiredArgsConstructor
+public class ServiceProvider extends Segment {
+
+    public static final String KEY = "SPR";
+
+    @NonNull
+    private final ServiceProviderCode serviceProviderCode;
+
+    public static ServiceProvider fromString(String edifactString) {
+        if (!edifactString.startsWith(KEY)) {
+            throw new IllegalArgumentException("Can't create " + ServiceProvider.class.getSimpleName() + " from " + edifactString);
+        }
+
+        String[] keySplit = Split.byPlus(edifactString);
+        String code = keySplit[1];
+
+        return new ServiceProvider(ServiceProviderCode.fromCode(code));
+    }
+
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    @Override
+    public String getValue() {
+        return serviceProviderCode.getCode();
+    }
+
+    @Override
+    protected void validateStateful() throws EdifactValidationException {
+
+    }
+
+    @Override
+    public void preValidate() throws EdifactValidationException {
+        if (serviceProviderCode.getCode().isBlank()) {
+            throw new EdifactValidationException(getKey() + ": Attribute code in serviceProviderCode is required");
+        }
+    }
+}

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ServiceProviderCode.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ServiceProviderCode.java
@@ -1,0 +1,25 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum ServiceProviderCode {
+    DEPARTMENT("DPT", "Department (within an organisation)"),
+    ORGANISATION("ORG", "Healthcare organisation"),
+    PROFESSIONAL("PRO", "Healthcare professional");
+
+    private final String code;
+    private final String description;
+
+    public static ServiceProviderCode fromCode(@NonNull String code) {
+        return Arrays.stream(ServiceProviderCode.values())
+                .filter(c -> code.equals(c.getCode()))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PerformingOrganisationNameAndAddressTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PerformingOrganisationNameAndAddressTest.java
@@ -1,0 +1,77 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
+
+import org.junit.jupiter.api.Test;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.EdifactValidationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PerformingOrganisationNameAndAddressTest {
+
+    private final PerformingOrganisationNameAndAddress performingOrganisationNameAndAddress =
+        new PerformingOrganisationNameAndAddress("LONDON CITY HOSPITAL");
+
+    @Test
+    void when_edifactStringDoesNotStartWithCorrectKey_expect_illegalArgumentExceptionIsThrown() {
+        assertThrows(IllegalArgumentException.class, () -> PerformingOrganisationNameAndAddress.fromString("wrong value"));
+    }
+
+    @Test
+    void when_edifactStringIsPassed_expect_returnAPerformingOrganisationNameAndAddressObject() {
+        assertThat(performingOrganisationNameAndAddress)
+            .usingRecursiveComparison()
+            .isEqualTo(PerformingOrganisationNameAndAddress.fromString("NAD+SLA+++LONDON CITY HOSPITAL"));
+    }
+
+    @Test
+    void when_mappingSegmentObjectToEdifactString_expect_returnCorrectEdifactString() {
+        String expectedEdifactString = "NAD+SLA+++LONDON CITY HOSPITAL'";
+
+        PerformingOrganisationNameAndAddress performingOrganisation = PerformingOrganisationNameAndAddress.builder()
+                .performingOrganisationName("LONDON CITY HOSPITAL")
+                .build();
+
+        assertEquals(expectedEdifactString, performingOrganisation.toEdifact());
+    }
+
+    @Test
+    void when_mappingSegmentObjectToEdifactStringWithEmptyField_expect_edifactValidationExceptionIsThrown() {
+        PerformingOrganisationNameAndAddress performingOrganisation = PerformingOrganisationNameAndAddress.builder()
+                .performingOrganisationName("")
+                .build();
+
+        assertThrows(EdifactValidationException.class, performingOrganisation::toEdifact);
+    }
+
+    @Test
+    void when_buildingSegmentObjectWithoutMandatoryField_expect_nullPointerExceptionIsThrown() {
+        assertThrows(NullPointerException.class, () -> PerformingOrganisationNameAndAddress.builder().build());
+    }
+
+    @Test
+    void testGetKey() {
+        assertEquals(performingOrganisationNameAndAddress.getKey(), "NAD");
+    }
+
+    @Test
+    void testGetValue() {
+        assertEquals(performingOrganisationNameAndAddress.getValue(), "SLA+++LONDON CITY HOSPITAL");
+    }
+
+    @Test
+    void testValidateStateful() {
+        assertDoesNotThrow(performingOrganisationNameAndAddress::validateStateful);
+    }
+
+    @Test
+    void testPreValidate() {
+        PerformingOrganisationNameAndAddress emptyPerformingOrganisationName = new PerformingOrganisationNameAndAddress("");
+
+        assertThatThrownBy(emptyPerformingOrganisationName::preValidate)
+            .isExactlyInstanceOf(EdifactValidationException.class)
+            .hasMessage("NAD: Attribute performingOrganisationName is required");
+    }
+}

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RequesterNameAndAddressTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RequesterNameAndAddressTest.java
@@ -1,0 +1,104 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
+
+import org.junit.jupiter.api.Test;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.EdifactValidationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RequesterNameAndAddressTest {
+
+    private final RequesterNameAndAddress requesterNameAndAddress = new RequesterNameAndAddress(
+        "ABC", HealthcareRegistrationIdentificationCode.GP, "SMITH"
+    );
+
+    @Test
+    void when_edifactStringDoesNotStartWithRequesterNameAndAddressKey_expect_illegalArgumentExceptionIsThrown() {
+        assertThrows(IllegalArgumentException.class, () -> RequesterNameAndAddress.fromString("wrong value"));
+    }
+
+    @Test
+    void when_edifactStringIsPassed_expect_returnARequesterNameAndAddressObject() {
+        assertThat(requesterNameAndAddress)
+            .usingRecursiveComparison()
+            .isEqualTo(RequesterNameAndAddress.fromString("NAD+PO+ABC:900++SMITH"));
+    }
+
+    @Test
+    void when_mappingSegmentObjectToEdifactString_expect_returnCorrectEdifactString() {
+        String expectedEdifactString = "NAD+PO+ABC:900++SMITH'";
+
+        RequesterNameAndAddress requester = RequesterNameAndAddress.builder()
+            .identifier("ABC")
+            .healthcareRegistrationIdentificationCode(HealthcareRegistrationIdentificationCode.GP)
+            .requesterName("SMITH")
+            .build();
+
+        assertEquals(expectedEdifactString, requester.toEdifact());
+    }
+
+    @Test
+    void when_mappingSegmentObjectToEdifactStringWithEmptyIdentifierField_expect_edifactValidationExceptionIsThrown() {
+        RequesterNameAndAddress requester = RequesterNameAndAddress.builder()
+            .identifier("")
+            .healthcareRegistrationIdentificationCode(HealthcareRegistrationIdentificationCode.GP)
+            .requesterName("SMITH")
+            .build();
+
+        assertThrows(EdifactValidationException.class, requester::toEdifact);
+    }
+
+    @Test
+    void when_mappingSegmentObjectToEdifactStringWithEmptyRequesterNameField_expect_edifactValidationExceptionIsThrown() {
+        RequesterNameAndAddress requester = RequesterNameAndAddress.builder()
+                .identifier("ABC")
+                .healthcareRegistrationIdentificationCode(HealthcareRegistrationIdentificationCode.GP)
+                .requesterName("")
+                .build();
+
+        assertThrows(EdifactValidationException.class, requester::toEdifact);
+    }
+
+    @Test
+    void when_buildingSegmentObjectWithoutMandatoryFields_expect_nullPointerExceptionIsThrown() {
+        assertThrows(NullPointerException.class, () -> RequesterNameAndAddress.builder().build());
+    }
+
+    @Test
+    void testGetKey() {
+        assertEquals(requesterNameAndAddress.getKey(), "NAD");
+    }
+
+    @Test
+    void testGetValue() {
+        assertEquals(requesterNameAndAddress.getValue(), "PO+ABC:900++SMITH");
+    }
+
+    @Test
+    void testValidateStateful() {
+        assertDoesNotThrow(requesterNameAndAddress::validateStateful);
+    }
+
+    @Test
+    void testPreValidate() {
+        RequesterNameAndAddress emptyIdentifier = new RequesterNameAndAddress(
+                "", HealthcareRegistrationIdentificationCode.GP, "SMITH"
+        );
+        RequesterNameAndAddress emptyRequesterName = new RequesterNameAndAddress(
+                "ABC", HealthcareRegistrationIdentificationCode.GP, ""
+        );
+
+        assertSoftly(softly -> {
+            softly.assertThatThrownBy(emptyIdentifier::preValidate)
+                    .isExactlyInstanceOf(EdifactValidationException.class)
+                    .hasMessage("NAD: Attribute identifier is required");
+
+            softly.assertThatThrownBy(emptyRequesterName::preValidate)
+                    .isExactlyInstanceOf(EdifactValidationException.class)
+                    .hasMessage("NAD: Attribute requesterName is required");
+        });
+    }
+}

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ServiceProviderTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ServiceProviderTest.java
@@ -1,0 +1,52 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ServiceProviderTest {
+
+    private final ServiceProvider serviceProvider = new ServiceProvider(
+            ServiceProviderCode.ORGANISATION
+    );
+
+    @Test
+    void when_edifactStringDoesNotStartWithCorrectKey_expect_illegalArgumentExceptionIsThrown() {
+        assertThrows(IllegalArgumentException.class, () -> ServiceProvider.fromString("wrong value"));
+    }
+
+    @Test
+    void when_edifactStringIsPassed_expect_returnAServiceProviderObject() {
+        assertThat(serviceProvider)
+                .usingRecursiveComparison()
+                .isEqualTo(ServiceProvider.fromString("SPR+ORG"));
+    }
+
+    @Test
+    void when_mappingSegmentObjectToEdifactString_expect_returnCorrectEdifactString() {
+        String expectedEdifactString = "SPR+ORG'";
+
+        ServiceProvider serviceProvider = ServiceProvider.builder()
+                .serviceProviderCode(ServiceProviderCode.ORGANISATION)
+                .build();
+
+        assertEquals(expectedEdifactString, serviceProvider.toEdifact());
+    }
+
+    @Test
+    void when_buildingSegmentObjectWithoutMandatoryField_expect_nullPointerExceptionIsThrown() {
+        assertThrows(NullPointerException.class, () -> ServiceProvider.builder().build());
+    }
+
+    @Test
+    void testGetKey() {
+        assertEquals(serviceProvider.getKey(), "SPR");
+    }
+
+    @Test
+    void testGetValue() {
+        assertEquals(serviceProvider.getValue(), "ORG");
+    }
+}


### PR DESCRIPTION
## Description

Add code to build SG1 segment objects from EDIFACT strings.

This is an example of an SG1 segment in an EDIFACT file:
```
S01+01'
NAD+PO+G3380314:900++SCOTT'
SPR+PRO'
S01+01'
NAD+MR+G3380314:900++SCOTT'
SPR+PRO'
S01+01'
NAD+MR+D82015:901'
SPR+ORG'
S01+01'
NAD+SLA+++Haematology'
SPR+DPT'
S01+01'
NAD+SLA+++ST JAMES?'S UNIVERSITY HOSPITAL'
SPR+ORG'
```

According to the pathology information model, we only need to map the `NAD` segments within SG1 (including `NAD+PO` and `NAD+SLA`, but not `NAD+MR`).

## Jira Ticket

https://gpitbjss.atlassian.net/browse/NIAD-873

## Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [x] Acceptance Criteria met
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] Self-reviewed your code
- [x] Code reviewed from two other developers
- [x] If your pull request depends on any other, please link them in the description
- [x] main branch is passing/green on CI
- [x] Add/update any relevant documentation