### PR TITLE
NIAD-963: Rename message queues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,9 @@ services:
       - LAB_RESULTS_AMQP_RETRY_DELAY=100
       - LAB_RESULTS_AMQP_MAX_RETRIES=3
       - LAB_RESULTS_AMQP_BROKERS=amqp://activemq:5672
-      - LAB_RESULTS_OUTBOUND_QUEUE_NAME=lab_results_outbound
+      - LAB_RESULTS_MESH_OUTBOUND_QUEUE_NAME=lab_results_mesh_outbound
+      - LAB_RESULTS_MESH_INBOUND_QUEUE_NAME=lab_results_mesh_inbound
+      - LAB_RESULTS_GP_OUTBOUND_QUEUE_NAME=lab_results_gp_outbound
       - LAB_RESULTS_MONGO_URI=mongodb://mongodb:27017
       - LAB_RESULTS_SSL_TRUST_STORE_URL=
       - LAB_RESULTS_SSL_TRUST_STORE_PASSWORD=

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/lab/results/IntegrationBaseTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/lab/results/IntegrationBaseTest.java
@@ -15,7 +15,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.nhs.digital.nhsconnect.lab.results.inbound.EdifactParser;
-import uk.nhs.digital.nhsconnect.lab.results.inbound.queue.InboundQueueService;
+import uk.nhs.digital.nhsconnect.lab.results.inbound.queue.MeshInboundQueueService;
 import uk.nhs.digital.nhsconnect.lab.results.mesh.RecipientMailboxIdMappings;
 import uk.nhs.digital.nhsconnect.lab.results.mesh.http.MeshClient;
 import uk.nhs.digital.nhsconnect.lab.results.mesh.http.MeshConfig;
@@ -67,7 +67,7 @@ public abstract class IntegrationBaseTest {
     @Autowired
     private MeshHttpClientBuilder meshHttpClientBuilder;
     @Autowired
-    private InboundQueueService inboundQueueService;
+    private MeshInboundQueueService meshInboundQueueService;
     @Autowired
     @Getter(AccessLevel.PROTECTED)
     private EdifactParser edifactParser;
@@ -201,7 +201,7 @@ public abstract class IntegrationBaseTest {
     }
 
     protected void sendToMeshInboundQueue(InboundMeshMessage meshMessage) {
-        inboundQueueService.publish(meshMessage);
+        meshInboundQueueService.publish(meshMessage);
     }
 
     protected void sendToMeshInboundQueue(String data) {

--- a/src/intTest/resources/application.yml
+++ b/src/intTest/resources/application.yml
@@ -10,7 +10,7 @@ logging:
 labresults:
   amqp:
     brokers: ${LAB_RESULTS_AMQP_BROKERS:amqp://localhost:5672}
-    meshOutboundQueueName: ${LAB_RESULTS_OUTBOUND_QUEUE_NAME:lab_results_mesh_outbound}
+    meshOutboundQueueName: ${LAB_RESULTS_MESH_OUTBOUND_QUEUE_NAME:lab_results_mesh_outbound}
     meshInboundQueueName: ${LAB_RESULTS_MESH_INBOUND_QUEUE_NAME:lab_results_mesh_inbound}
     gpOutboundQueueName: ${LAB_RESULTS_GP_OUTBOUND_QUEUE_NAME:lab_results_gp_outbound}
     exchange: amq.direct

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/inbound/queue/MeshInboundQueueService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/inbound/queue/MeshInboundQueueService.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 @Component
 @Slf4j
 @RequiredArgsConstructor(onConstructor_ = @Autowired)
-public class InboundQueueService {
+public class MeshInboundQueueService {
 
     private final ObjectMapper objectMapper;
 

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/MeshService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/MeshService.java
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import uk.nhs.digital.nhsconnect.lab.results.inbound.queue.InboundQueueService;
+import uk.nhs.digital.nhsconnect.lab.results.inbound.queue.MeshInboundQueueService;
 import uk.nhs.digital.nhsconnect.lab.results.mesh.exception.MeshWorkflowUnknownException;
 import uk.nhs.digital.nhsconnect.lab.results.mesh.http.MeshClient;
 import uk.nhs.digital.nhsconnect.lab.results.mesh.message.InboundMeshMessage;
@@ -21,7 +21,7 @@ public class MeshService {
 
     private final MeshClient meshClient;
 
-    private final InboundQueueService inboundQueueService;
+    private final MeshInboundQueueService meshInboundQueueService;
 
     private final MeshMailBoxScheduler meshMailBoxScheduler;
 
@@ -35,14 +35,14 @@ public class MeshService {
 
     @Autowired
     public MeshService(MeshClient meshClient,
-                       InboundQueueService inboundQueueService,
+                       MeshInboundQueueService meshInboundQueueService,
                        MeshMailBoxScheduler meshMailBoxScheduler,
                        ConversationIdService conversationIdService,
                        @Value("${labresults.mesh.pollingCycleMinimumIntervalInSeconds}") long pollingCycleMinimumIntervalInSeconds,
                        @Value("${labresults.mesh.wakeupIntervalInMilliseconds}") long wakeupIntervalInMilliseconds,
                        @Value("${labresults.mesh.pollingCycleDurationInSeconds}") long pollingCycleDurationInSeconds) {
         this.meshClient = meshClient;
-        this.inboundQueueService = inboundQueueService;
+        this.meshInboundQueueService = meshInboundQueueService;
         this.meshMailBoxScheduler = meshMailBoxScheduler;
         this.conversationIdService = conversationIdService;
         this.pollingCycleMinimumIntervalInSeconds = pollingCycleMinimumIntervalInSeconds;
@@ -99,7 +99,7 @@ public class MeshService {
             LOGGER.debug("Downloading MeshMessageId={}", messageId);
             final InboundMeshMessage meshMessage = meshClient.getEdifactMessage(messageId);
             LOGGER.debug("Publishing content of MeshMessageId={} to inbound mesh MQ", messageId);
-            inboundQueueService.publish(meshMessage);
+            meshInboundQueueService.publish(meshMessage);
             LOGGER.debug("Acknowledging MeshMessageId={} on MESH API", messageId);
             meshClient.acknowledgeMessage(meshMessage.getMeshMessageId());
             LOGGER.info("Published MeshMessageId={} for inbound processing", meshMessage.getMeshMessageId());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
 labresults:
   amqp:
     brokers: ${LAB_RESULTS_AMQP_BROKERS:amqp://localhost:5672}
-    meshOutboundQueueName: ${LAB_RESULTS_OUTBOUND_QUEUE_NAME:lab_results_mesh_outbound}
+    meshOutboundQueueName: ${LAB_RESULTS_MESH_OUTBOUND_QUEUE_NAME:lab_results_mesh_outbound}
     meshInboundQueueName: ${LAB_RESULTS_MESH_INBOUND_QUEUE_NAME:lab_results_mesh_inbound}
     gpOutboundQueueName: ${LAB_RESULTS_GP_OUTBOUND_QUEUE_NAME:lab_results_gp_outbound}
     exchange: amq.direct

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/queue/MeshInboundQueueServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/queue/MeshInboundQueueServiceTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class InboundQueueServiceTest {
+class MeshInboundQueueServiceTest {
 
     private static final String CONVERSATION_ID = "CONV123";
 
@@ -50,7 +50,7 @@ class InboundQueueServiceTest {
     private ArgumentCaptor<MessageCreator> jmsMessageCreatorCaptor;
 
     @InjectMocks
-    private InboundQueueService inboundQueueService;
+    private MeshInboundQueueService meshInboundQueueService;
 
     @Mock
     private JmsTemplate jmsTemplate;
@@ -69,7 +69,7 @@ class InboundQueueServiceTest {
         when(message.getStringProperty(JmsHeaders.CONVERSATION_ID)).thenReturn(CONVERSATION_ID);
         when(message.getBody(String.class)).thenReturn("{\"workflowId\":\"LAB_RESULTS_REG\"}");
 
-        inboundQueueService.receive(message);
+        meshInboundQueueService.receive(message);
 
         verify(conversationIdService).applyConversationId(CONVERSATION_ID);
 
@@ -86,7 +86,7 @@ class InboundQueueServiceTest {
         when(message.getStringProperty(JmsHeaders.CONVERSATION_ID)).thenReturn(CONVERSATION_ID);
         when(message.getBody(String.class)).thenReturn("{\"workflowId\":\"INVALID\"}");
 
-        assertThrows(Exception.class, () -> inboundQueueService.receive(message));
+        assertThrows(Exception.class, () -> meshInboundQueueService.receive(message));
 
         verify(conversationIdService).applyConversationId(CONVERSATION_ID);
         verify(message, never()).acknowledge();
@@ -99,7 +99,7 @@ class InboundQueueServiceTest {
         when(message.getBody(String.class)).thenReturn("{\"workflowId\":\"LAB_RESULTS_REG\"}");
         doThrow(RuntimeException.class).when(inboundMessageHandler).handle(any(MeshMessage.class));
 
-        assertThrows(RuntimeException.class, () -> inboundQueueService.receive(message));
+        assertThrows(RuntimeException.class, () -> meshInboundQueueService.receive(message));
 
         verify(conversationIdService).applyConversationId(CONVERSATION_ID);
         verify(message, never()).acknowledge();
@@ -111,7 +111,7 @@ class InboundQueueServiceTest {
         doThrow(JMSException.class).when(message).getStringProperty(JmsHeaders.CONVERSATION_ID);
         when(message.getBody(String.class)).thenReturn("{\"workflowId\":\"LAB_RESULTS_REG\"}");
 
-        inboundQueueService.receive(message);
+        meshInboundQueueService.receive(message);
 
         verify(conversationIdService, never()).applyConversationId(CONVERSATION_ID);
 
@@ -133,7 +133,7 @@ class InboundQueueServiceTest {
         final InboundMeshMessage inboundMeshMessage = InboundMeshMessage.create(WorkflowId.REGISTRATION,
             "ASDF", null, "ID123");
 
-        inboundQueueService.publish(inboundMeshMessage);
+        meshInboundQueueService.publish(inboundMeshMessage);
 
         // the method parameter is modified so another copy is needed. Timestamp set to expected value
         final InboundMeshMessage expectedInboundMeshMessage = InboundMeshMessage.create(WorkflowId.REGISTRATION,

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -8,7 +8,7 @@ logging:
 labresults:
   amqp:
     brokers: ${LAB_RESULTS_AMQP_BROKERS:amqp://localhost:5672}
-    meshOutboundQueueName: ${LAB_RESULTS_OUTBOUND_QUEUE_NAME:lab_results_mesh_outbound}
+    meshOutboundQueueName: ${LAB_RESULTS_MESH_OUTBOUND_QUEUE_NAME:lab_results_mesh_outbound}
     meshInboundQueueName: ${LAB_RESULTS_MESH_INBOUND_QUEUE_NAME:lab_results_mesh_inbound}
     gpOutboundQueueName: ${LAB_RESULTS_GP_OUTBOUND_QUEUE_NAME:lab_results_gp_outbound}
     exchange: amq.direct


### PR DESCRIPTION
## Description

Updated message queue names and added missing configuration to the docker-compose, as per acceptance criteria. 

Verified the following:

- Inbound Mesh Queue: message is downloaded from mesh mailbox and put on this queue
- Outbound GP Queue: message is sent to GP via this queue
- Outbound Mesh Queue: recep message is sent to mesh mailbox via this queue

## Jira Ticket

https://gpitbjss.atlassian.net/browse/NIAD-963

## Screenshot

Queues in ActiveMQ - same result for running application in docker container and Intellij 
<img width="1297" alt="Screenshot 2021-02-03 at 11 47 05" src="https://user-images.githubusercontent.com/16392604/106744319-85342480-6617-11eb-9a4d-267d5da37d29.png">

## Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [ ] Acceptance Criteria met
- [ ] Commit messages are meaningful
- [x] Manually tested
- [ ] Self-reviewed your code
- [ ] Code reviewed from two other developers
- [ ] If your pull request depends on any other, please link them in the description
- [ ] main branch is passing/green on CI
- [ ] Add/update any relevant documentation
