### PR TITLE
NIAD-1012: Add SG18 segment code to build segment objects from EDIFACT strings.

### DIFF
--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DeviatingResultIndicator.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DeviatingResultIndicator.java
@@ -1,0 +1,25 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum DeviatingResultIndicator {
+    ABOVE_HIGH_REFERENCE_LIMIT("HI", "Above high reference limit"),
+    BELOW_LOW_REFERENCE_LIMIT("LO", "Below low reference limit"),
+    OUTSIDE_REFERENCE_LIMIT("OR", "Outside reference range"),
+    POTENTIALLY_ABNORMAL("PA", "Potentially abnormal");
+
+    private final String code;
+    private final String description;
+
+    public static DeviatingResultIndicator fromCode(String code) {
+        return Arrays.stream(DeviatingResultIndicator.values())
+                .filter(c -> c.code.equals(code))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DiagnosticReportCode.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DiagnosticReportCode.java
@@ -21,7 +21,7 @@ public class DiagnosticReportCode extends Segment {
     private final String code;
 
     public static DiagnosticReportCode fromString(final String edifactString) {
-        if (!edifactString.startsWith(DiagnosticReportCode.KEY)) {
+        if (!edifactString.startsWith(KEY)) {
             throw new IllegalArgumentException("Can't create " + DiagnosticReportCode.class.getSimpleName() + " from " + edifactString);
         }
         final String[] keySplit = Split.byPlus(edifactString);

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DiagnosticReportDateIssued.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DiagnosticReportDateIssued.java
@@ -31,7 +31,7 @@ public class DiagnosticReportDateIssued extends Segment {
         DateTimeFormatter.ofPattern("yyyMMddHHmm").withZone(TimestampService.UK_ZONE);
 
     public static DiagnosticReportDateIssued fromString(final String edifactString) {
-        if (!edifactString.startsWith(DiagnosticReportDateIssued.KEY_QUALIFIER)) {
+        if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException("Can't create " + DiagnosticReportDateIssued.class.getSimpleName()
                 + " from " + edifactString);
         }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/GpNameAndAddress.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/GpNameAndAddress.java
@@ -28,7 +28,7 @@ public class GpNameAndAddress extends Segment {
     private String code;
 
     public static GpNameAndAddress fromString(final String edifactString) {
-        if (!edifactString.startsWith(GpNameAndAddress.KEY_QUALIFIER)) {
+        if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException("Can't create " + GpNameAndAddress.class.getSimpleName()
                     + " from " + edifactString);
         }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/HealthAuthorityNameAndAddress.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/HealthAuthorityNameAndAddress.java
@@ -51,7 +51,7 @@ public class HealthAuthorityNameAndAddress extends Segment {
     }
 
     public static HealthAuthorityNameAndAddress fromString(final String edifactString) {
-        if (!edifactString.startsWith(HealthAuthorityNameAndAddress.KEY_QUALIFIER)) {
+        if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException("Can't create " + HealthAuthorityNameAndAddress.class.getSimpleName()
                     + " from " + edifactString);
         }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/InterchangeHeader.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/InterchangeHeader.java
@@ -42,7 +42,7 @@ public class InterchangeHeader extends Segment {
     private Long sequenceNumber;
 
     public static InterchangeHeader fromString(final String edifactString) {
-        if (!edifactString.startsWith(InterchangeHeader.KEY)) {
+        if (!edifactString.startsWith(KEY)) {
             throw new IllegalArgumentException("Can't create " + InterchangeHeader.class.getSimpleName() + " from " + edifactString);
         }
 

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/InterchangeTrailer.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/InterchangeTrailer.java
@@ -47,7 +47,7 @@ public class InterchangeTrailer extends Segment {
     }
 
     public static InterchangeTrailer fromString(String edifactString) {
-        if (!edifactString.startsWith(InterchangeTrailer.KEY)) {
+        if (!edifactString.startsWith(KEY)) {
             throw new IllegalArgumentException("Can't create " + InterchangeTrailer.class.getSimpleName() + " from " + edifactString);
         }
         String[] split = Split.byPlus(

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/LaboratoryInvestigation.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/LaboratoryInvestigation.java
@@ -1,0 +1,72 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import org.apache.commons.lang3.StringUtils;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.EdifactValidationException;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.Split;
+
+/**
+ * Example: INV+MQ+42R4.:911::Serum ferritin'
+ */
+@AllArgsConstructor
+@Getter
+@Builder
+public class LaboratoryInvestigation extends Segment {
+
+    private static final String KEY = "INV";
+    private static final String QUALIFIER = "MQ";
+    private static final String KEY_QUALIFIER = KEY + PLUS_SEPARATOR + QUALIFIER;
+    private static final String FIVE_BYTE_READ_CODE = "911";
+
+    private static final int INVESTIGATION_CODE_INDEX = 0;
+    private static final int INVESTIGATION_DESCRIPTION_INDEX = 3;
+
+    private final String investigationCode;
+    @NonNull
+    private final String investigationDescription;
+
+    public static LaboratoryInvestigation fromString(String edifactString) {
+        if (!edifactString.startsWith(KEY_QUALIFIER)) {
+            throw new IllegalArgumentException("Can't create " + LaboratoryInvestigation.class.getSimpleName() + " from " + edifactString);
+        }
+
+        String[] keySplit = Split.byPlus(edifactString);
+        String investigationCode = Split.byColon(keySplit[2])[INVESTIGATION_CODE_INDEX];
+        String investigationDescription = Split.byColon(keySplit[2])[INVESTIGATION_DESCRIPTION_INDEX];
+
+        return new LaboratoryInvestigation(investigationCode, investigationDescription);
+    }
+
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    @Override
+    public String getValue() {
+        String fiveByteReadCode = !investigationCode.isBlank() ? FIVE_BYTE_READ_CODE : "";
+
+        return QUALIFIER
+                + PLUS_SEPARATOR
+                + investigationCode
+                + COLON_SEPARATOR
+                + fiveByteReadCode
+                + COLON_SEPARATOR + COLON_SEPARATOR
+                + investigationDescription;
+    }
+
+    @Override
+    protected void validateStateful() throws EdifactValidationException {
+
+    }
+
+    @Override
+    public void preValidate() throws EdifactValidationException {
+        if (StringUtils.isBlank(investigationDescription)) {
+            throw new EdifactValidationException(getKey() + ": Attribute investigationDescription is required");
+        }
+    }
+}

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/LaboratoryInvestigationResult.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/LaboratoryInvestigationResult.java
@@ -1,0 +1,120 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.EdifactValidationException;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.Split;
+
+import java.math.BigDecimal;
+
+/**
+ * Example: RSL+NV+11.9:7++:::ng/mL+HI'
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class LaboratoryInvestigationResult extends Segment {
+
+    private static final String KEY = "RSL";
+    private static final String QUALIFIER = "NV";
+    private static final String KEY_QUALIFIER = KEY + PLUS_SEPARATOR + QUALIFIER;
+
+    private static final int MEASUREMENT_UNIT_SECTION = 4;
+    private static final int MEASUREMENT_UNIT_INDEX = 3;
+    private static final int DEVIATING_RESULT_INDICATOR_INDEX = 5;
+
+    private final BigDecimal measurementValue;
+    private final MeasurementValueComparator measurementValueComparator;
+    private final String measurementUnit;
+    private final DeviatingResultIndicator deviatingResultIndicator;
+
+    public static LaboratoryInvestigationResult fromString(String edifactString) {
+        if (!edifactString.startsWith(KEY_QUALIFIER)) {
+            throw new IllegalArgumentException("Can't create "
+                    + LaboratoryInvestigationResult.class.getSimpleName() + " from " + edifactString);
+        }
+
+        String[] keySplit = Split.byPlus(edifactString);
+
+        BigDecimal measurementValue = extractMeasurementValue(keySplit);
+        String measurementValueComparator = extractMeasurementValueComparator(keySplit);
+        String measurementUnit = extractMeasurementUnit(keySplit);
+        String deviatingResultIndicator = extractDeviatingResultIndicator(keySplit);
+
+        return new LaboratoryInvestigationResult(
+                measurementValue,
+                MeasurementValueComparator.fromCode(measurementValueComparator),
+                measurementUnit,
+                DeviatingResultIndicator.fromCode(deviatingResultIndicator)
+        );
+    }
+
+    private static BigDecimal extractMeasurementValue(String[] keySplit) {
+        if (StringUtils.isNotBlank(keySplit[2])) {
+            return new BigDecimal(Split.byColon(keySplit[2])[0]);
+        }
+
+        return null;
+    }
+
+    private static String extractMeasurementValueComparator(String[] keySplit) {
+        if (StringUtils.isNotBlank(keySplit[2]) && Split.byColon(keySplit[2]).length >= 2) {
+            return Split.byColon(keySplit[2])[1];
+        }
+
+        return null;
+    }
+
+    private static String extractMeasurementUnit(String[] keySplit) {
+        if (StringUtils.isNotBlank(keySplit[MEASUREMENT_UNIT_SECTION])) {
+            return Split.byColon(keySplit[MEASUREMENT_UNIT_SECTION])[MEASUREMENT_UNIT_INDEX];
+        }
+
+        return null;
+    }
+
+    private static String extractDeviatingResultIndicator(String[] keySplit) {
+        if (DEVIATING_RESULT_INDICATOR_INDEX < keySplit.length) {
+            return keySplit[DEVIATING_RESULT_INDICATOR_INDEX];
+        }
+
+        return null;
+    }
+
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    @Override
+    public String getValue() {
+        return QUALIFIER
+                + PLUS_SEPARATOR
+                + measurementValue
+                + COLON_SEPARATOR
+                + measurementValueComparator.getCode()
+                + PLUS_SEPARATOR + PLUS_SEPARATOR
+                + COLON_SEPARATOR + COLON_SEPARATOR + COLON_SEPARATOR
+                + measurementUnit
+                + PLUS_SEPARATOR
+                + deviatingResultIndicator.getCode();
+    }
+
+    @Override
+    protected void validateStateful() throws EdifactValidationException {
+
+    }
+
+    @Override
+    public void preValidate() throws EdifactValidationException {
+        if (measurementValue == null) {
+            throw new EdifactValidationException(getKey() + ": Attribute measurementValue is required");
+        }
+
+        if (StringUtils.isBlank(measurementUnit)) {
+            throw new EdifactValidationException(getKey() + ": Attribute measurementUnit is required");
+        }
+    }
+}

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MeasurementValueComparator.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MeasurementValueComparator.java
@@ -1,0 +1,25 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum MeasurementValueComparator {
+    GREATER_THAN_OR_EQUAL_TO("5", ">="),
+    GREATER_THAN("6", ">"),
+    LESS_THAN("7", "<"),
+    LESS_THAN_OR_EQUAL_TO("8", "<=");
+
+    private final String code;
+    private final String description;
+
+    public static MeasurementValueComparator fromCode(String code) {
+        return Arrays.stream(MeasurementValueComparator.values())
+                .filter(c -> c.code.equals(code))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageHeader.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageHeader.java
@@ -48,7 +48,7 @@ public class MessageHeader extends Segment {
     public void preValidate() { }
 
     public static MessageHeader fromString(final String edifactString) {
-        if (!edifactString.startsWith(MessageHeader.KEY)) {
+        if (!edifactString.startsWith(KEY)) {
             throw new IllegalArgumentException("Can't create " + MessageHeader.class.getSimpleName() + " from " + edifactString);
         }
         String[] split = Split.byPlus(edifactString);

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageTrailer.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageTrailer.java
@@ -49,7 +49,7 @@ public class MessageTrailer extends Segment {
     public void preValidate() throws EdifactValidationException { }
 
     public static MessageTrailer fromString(String edifactString) {
-        if (!edifactString.startsWith(MessageTrailer.KEY)) {
+        if (!edifactString.startsWith(KEY)) {
             throw new IllegalArgumentException("Can't create " + MessageTrailer.class.getSimpleName() + " from " + edifactString);
         }
         String[] split = Split.byPlus(

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PerformingOrganisationNameAndAddress.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PerformingOrganisationNameAndAddress.java
@@ -26,7 +26,7 @@ public class PerformingOrganisationNameAndAddress extends Segment {
     private final String performingOrganisationName;
 
     public static PerformingOrganisationNameAndAddress fromString(String edifactString) {
-        if (!edifactString.startsWith(PerformingOrganisationNameAndAddress.KEY_QUALIFIER)) {
+        if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException(
                 "Can't create " + PerformingOrganisationNameAndAddress.class.getSimpleName() + " from " + edifactString
             );

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonDateOfBirth.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonDateOfBirth.java
@@ -60,7 +60,7 @@ public class PersonDateOfBirth extends Segment {
     }
 
     public static PersonDateOfBirth fromString(final String edifactString) {
-        if (!edifactString.startsWith(PersonDateOfBirth.KEY_QUALIFIER)) {
+        if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException("Can't create " + PersonDateOfBirth.class.getSimpleName() + " from " + edifactString);
         }
         final String input = Split.byPlus(edifactString)[1];

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonName.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonName.java
@@ -83,7 +83,7 @@ public class PersonName extends Segment {
     }
 
     public static PersonName fromString(final String edifactString) {
-        if (!edifactString.startsWith(PersonName.KEY_QUALIFIER)) {
+        if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException("Can't create " + PersonName.class.getSimpleName() + " from " + edifactString);
         }
 

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonSex.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonSex.java
@@ -38,7 +38,7 @@ public class PersonSex extends Segment {
     }
 
     public static PersonSex fromString(final String edifactString) {
-        if (!edifactString.startsWith(PersonSex.KEY)) {
+        if (!edifactString.startsWith(KEY)) {
             throw new IllegalArgumentException("Can't create " + PersonSex.class.getSimpleName() + " from " + edifactString);
         }
         final String[] components = Split.byPlus(Split.bySegmentTerminator(edifactString)[0]);

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ReferenceTransactionNumber.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ReferenceTransactionNumber.java
@@ -46,7 +46,7 @@ public class ReferenceTransactionNumber extends Segment {
     }
 
     public static ReferenceTransactionNumber fromString(String edifactString) {
-        if (!edifactString.startsWith(ReferenceTransactionNumber.KEY_QUALIFIER)) {
+        if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException("Can't create " + ReferenceTransactionNumber.class.getSimpleName()
                 + " from " + edifactString);
         }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ReferenceTransactionType.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ReferenceTransactionType.java
@@ -20,7 +20,7 @@ public class ReferenceTransactionType extends Segment {
     private @NonNull TransactionType transactionType;
 
     public static ReferenceTransactionType fromString(final String edifactString) {
-        if (!edifactString.startsWith(ReferenceTransactionType.KEY_QUALIFIER)) {
+        if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException("Can't create " + ReferenceTransactionType.class.getSimpleName() + " from " + edifactString);
         }
         final String[] split = Split.byColon(edifactString);

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RequesterNameAndAddress.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RequesterNameAndAddress.java
@@ -30,7 +30,7 @@ public class RequesterNameAndAddress extends Segment {
     private final String requesterName;
 
     public static RequesterNameAndAddress fromString(String edifactString) {
-        if (!edifactString.startsWith(RequesterNameAndAddress.KEY_QUALIFIER)) {
+        if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException("Can't create " + RequesterNameAndAddress.class.getSimpleName() + " from " + edifactString);
         }
 

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/TestStatus.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/TestStatus.java
@@ -1,0 +1,56 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.util.ObjectUtils;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.EdifactValidationException;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.Split;
+
+/**
+ * Example: STS++CO'
+ */
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class TestStatus extends Segment {
+
+    public static final String KEY = "STS";
+
+    @NonNull
+    private final TestStatusCode testStatusCode;
+
+    public static TestStatus fromString(String edifactString) {
+        if (!edifactString.startsWith(KEY)) {
+            throw new IllegalArgumentException("Can't create " + TestStatus.class.getSimpleName() + " from " + edifactString);
+        }
+
+        String[] keySplit = Split.byPlus(edifactString);
+        String code = keySplit[2];
+
+        return new TestStatus(TestStatusCode.fromCode(code));
+    }
+
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    @Override
+    public String getValue() {
+        return testStatusCode.getCode();
+    }
+
+    @Override
+    protected void validateStateful() throws EdifactValidationException {
+
+    }
+
+    @Override
+    public void preValidate() throws EdifactValidationException {
+        if (ObjectUtils.isEmpty(testStatusCode)) {
+            throw new EdifactValidationException(getKey() + ": Attribute code in testStatusCode is required");
+        }
+    }
+}

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/TestStatusCode.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/TestStatusCode.java
@@ -1,0 +1,30 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum TestStatusCode {
+    REGISTERED("RE", "Registered"),
+    PRELIMINARY("PR", "Preliminary"),
+    FINAL("FI", "Final"),
+    AMENDED("AM", "Amended"),
+    CORRECTED("CO", "Corrected"),
+    CANCELLED("CA", "Cancelled"),
+    ENTERED_IN_ERROR("EN", "Entered in Error"),
+    UNKNOWN("UN", "Unknown");
+
+    private final String code;
+    private final String description;
+
+    public static TestStatusCode fromCode(@NonNull String code) {
+        return Arrays.stream(TestStatusCode.values())
+                .filter(c -> code.equals(c.getCode()))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/LaboratoryInvestigationResultTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/LaboratoryInvestigationResultTest.java
@@ -1,0 +1,107 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
+
+import org.junit.jupiter.api.Test;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.EdifactValidationException;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class LaboratoryInvestigationResultTest {
+
+    private final LaboratoryInvestigationResult laboratoryInvestigationResult = new LaboratoryInvestigationResult(
+            new BigDecimal("11.9"), MeasurementValueComparator.LESS_THAN, "ng/mL", DeviatingResultIndicator.ABOVE_HIGH_REFERENCE_LIMIT
+    );
+
+    @Test
+    void when_edifactStringDoesNotStartWithLaboratoryInvestigationResultKey_expect_illegalArgumentExceptionIsThrown() {
+        assertThrows(IllegalArgumentException.class, () -> LaboratoryInvestigationResult.fromString("wrong value"));
+    }
+
+    @Test
+    void when_edifactString1IsPassed_expect_returnALaboratoryInvestigationResultObject() {
+        assertThat(laboratoryInvestigationResult)
+            .usingRecursiveComparison()
+            .isEqualTo(LaboratoryInvestigationResult.fromString("RSL+NV+11.9:7++:::ng/mL+HI"));
+    }
+
+    @Test
+    void when_edifactString2IsPassed_expect_returnALaboratoryInvestigationResultObject() {
+        final LaboratoryInvestigationResult laboratoryInvestigationResult = new LaboratoryInvestigationResult(
+                new BigDecimal("11.9"), null, "ng/mL", DeviatingResultIndicator.ABOVE_HIGH_REFERENCE_LIMIT
+        );
+
+        assertThat(laboratoryInvestigationResult)
+                .usingRecursiveComparison()
+                .isEqualTo(LaboratoryInvestigationResult.fromString("RSL+NV+11.9++:::ng/mL+HI"));
+    }
+
+    @Test
+    void when_edifactString3IsPassed_expect_returnALaboratoryInvestigationResultObject() {
+        final LaboratoryInvestigationResult laboratoryInvestigationResult = new LaboratoryInvestigationResult(
+                new BigDecimal("11.9"), null, "ng/mL", null
+        );
+
+        assertThat(laboratoryInvestigationResult)
+                .usingRecursiveComparison()
+                .isEqualTo(LaboratoryInvestigationResult.fromString("RSL+NV+11.9++:::ng/mL"));
+    }
+
+    @Test
+    void when_mappingSegmentObjectToEdifactString_expect_returnCorrectEdifactString() {
+        String expectedEdifactString = "RSL+NV+11.9:7++:::ng/mL+HI'";
+
+        LaboratoryInvestigationResult laboratoryInvestigationResult = LaboratoryInvestigationResult.builder()
+            .measurementValue(new BigDecimal("11.9"))
+            .measurementValueComparator(MeasurementValueComparator.LESS_THAN)
+            .measurementUnit("ng/mL")
+            .deviatingResultIndicator(DeviatingResultIndicator.ABOVE_HIGH_REFERENCE_LIMIT)
+            .build();
+
+        assertEquals(expectedEdifactString, laboratoryInvestigationResult.toEdifact());
+    }
+
+    @Test
+    void when_buildingSegmentObjectWithoutAnyFields_expect_nullPointerExceptionIsThrown() {
+        assertThrows(NullPointerException.class, () -> LaboratoryInvestigation.builder().build());
+    }
+
+    @Test
+    void testGetKey() {
+        assertEquals(laboratoryInvestigationResult.getKey(), "RSL");
+    }
+
+    @Test
+    void testGetValue() {
+        assertEquals(laboratoryInvestigationResult.getValue(), "NV+11.9:7++:::ng/mL+HI");
+    }
+
+    @Test
+    void testValidateStateful() {
+        assertDoesNotThrow(laboratoryInvestigationResult::validateStateful);
+    }
+
+    @Test
+    void testPreValidate() {
+        LaboratoryInvestigationResult emptyMeasurementValue = new LaboratoryInvestigationResult(
+                null, MeasurementValueComparator.LESS_THAN, "ng/mL", DeviatingResultIndicator.ABOVE_HIGH_REFERENCE_LIMIT
+        );
+        LaboratoryInvestigationResult emptyMeasurementUnit = new LaboratoryInvestigationResult(
+                new BigDecimal("11.9"), MeasurementValueComparator.LESS_THAN, null, DeviatingResultIndicator.ABOVE_HIGH_REFERENCE_LIMIT
+        );
+
+        assertAll(
+            () -> assertThatThrownBy(emptyMeasurementValue::preValidate)
+                    .isExactlyInstanceOf(EdifactValidationException.class)
+                    .hasMessage("RSL: Attribute measurementValue is required"),
+            () -> assertThatThrownBy(emptyMeasurementUnit::preValidate)
+                    .isExactlyInstanceOf(EdifactValidationException.class)
+                    .hasMessage("RSL: Attribute measurementUnit is required")
+        );
+    }
+}

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/LaboratoryInvestigationTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/LaboratoryInvestigationTest.java
@@ -1,0 +1,82 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
+
+import org.junit.jupiter.api.Test;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.EdifactValidationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class LaboratoryInvestigationTest {
+
+    private final LaboratoryInvestigation laboratoryInvestigation = new LaboratoryInvestigation(
+        "42R4.", "Serum ferritin"
+    );
+
+    @Test
+    void when_edifactStringDoesNotStartWithLaboratoryInvestigationKey_expect_illegalArgumentExceptionIsThrown() {
+        assertThrows(IllegalArgumentException.class, () -> LaboratoryInvestigation.fromString("wrong value"));
+    }
+
+    @Test
+    void when_edifactStringIsPassed_expect_returnALaboratoryInvestigationObject() {
+        assertThat(laboratoryInvestigation)
+            .usingRecursiveComparison()
+            .isEqualTo(LaboratoryInvestigation.fromString("INV+MQ+42R4.:911::Serum ferritin"));
+    }
+
+    @Test
+    void when_mappingSegmentObjectToEdifactString_expect_returnCorrectEdifactString() {
+        String expectedEdifactString = "INV+MQ+42R4.:911::Serum ferritin'";
+
+        LaboratoryInvestigation laboratoryInvestigation = LaboratoryInvestigation.builder()
+            .investigationCode("42R4.")
+            .investigationDescription("Serum ferritin")
+            .build();
+
+        assertEquals(expectedEdifactString, laboratoryInvestigation.toEdifact());
+    }
+
+    @Test
+    void when_mappingSegmentObjectToEdifactStringWithEmptyDescriptionField_expect_edifactValidationExceptionIsThrown() {
+        LaboratoryInvestigation laboratoryInvestigation = LaboratoryInvestigation.builder()
+            .investigationCode("42R4.")
+            .investigationDescription("")
+            .build();
+
+        assertThrows(EdifactValidationException.class, laboratoryInvestigation::toEdifact);
+    }
+
+    @Test
+    void when_buildingSegmentObjectWithoutAnyFields_expect_nullPointerExceptionIsThrown() {
+        assertThrows(NullPointerException.class, () -> LaboratoryInvestigation.builder().build());
+    }
+
+    @Test
+    void testGetKey() {
+        assertEquals(laboratoryInvestigation.getKey(), "INV");
+    }
+
+    @Test
+    void testGetValue() {
+        assertEquals(laboratoryInvestigation.getValue(), "MQ+42R4.:911::Serum ferritin");
+    }
+
+    @Test
+    void testValidateStateful() {
+        assertDoesNotThrow(laboratoryInvestigation::validateStateful);
+    }
+
+    @Test
+    void testPreValidate() {
+        LaboratoryInvestigation emptyDescription = new LaboratoryInvestigation(
+                "42R4.", ""
+        );
+
+        assertThatThrownBy(emptyDescription::preValidate)
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("INV: Attribute investigationDescription is required");
+    }
+}

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RequesterNameAndAddressTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RequesterNameAndAddressTest.java
@@ -4,7 +4,8 @@ import org.junit.jupiter.api.Test;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.EdifactValidationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -91,14 +92,13 @@ class RequesterNameAndAddressTest {
                 "ABC", HealthcareRegistrationIdentificationCode.GP, ""
         );
 
-        assertSoftly(softly -> {
-            softly.assertThatThrownBy(emptyIdentifier::preValidate)
+        assertAll(
+            () -> assertThatThrownBy(emptyIdentifier::preValidate)
                     .isExactlyInstanceOf(EdifactValidationException.class)
-                    .hasMessage("NAD: Attribute identifier is required");
-
-            softly.assertThatThrownBy(emptyRequesterName::preValidate)
+                    .hasMessage("NAD: Attribute identifier is required"),
+            () -> assertThatThrownBy(emptyRequesterName::preValidate)
                     .isExactlyInstanceOf(EdifactValidationException.class)
-                    .hasMessage("NAD: Attribute requesterName is required");
-        });
+                    .hasMessage("NAD: Attribute requesterName is required")
+        );
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/TestStatusTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/TestStatusTest.java
@@ -1,0 +1,52 @@
+package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TestStatusTest {
+
+    private final TestStatus testStatus = new TestStatus(
+            TestStatusCode.CORRECTED
+    );
+
+    @Test
+    void when_edifactStringDoesNotStartWithCorrectKey_expect_illegalArgumentExceptionIsThrown() {
+        assertThrows(IllegalArgumentException.class, () -> TestStatus.fromString("wrong value"));
+    }
+
+    @Test
+    void when_edifactStringIsPassed_expect_returnATestStatusObject() {
+        assertThat(testStatus)
+                .usingRecursiveComparison()
+                .isEqualTo(TestStatus.fromString("STS++CO"));
+    }
+
+    @Test
+    void when_mappingSegmentObjectToEdifactString_expect_returnCorrectEdifactString() {
+        String expectedEdifactString = "STS+CO'";
+
+        TestStatus testStatus = TestStatus.builder()
+                .testStatusCode(TestStatusCode.CORRECTED)
+                .build();
+
+        assertEquals(expectedEdifactString, testStatus.toEdifact());
+    }
+
+    @Test
+    void when_buildingSegmentObjectWithoutMandatoryField_expect_nullPointerExceptionIsThrown() {
+        assertThrows(NullPointerException.class, () -> TestStatus.builder().build());
+    }
+
+    @Test
+    void testGetKey() {
+        assertEquals(testStatus.getKey(), "STS");
+    }
+
+    @Test
+    void testGetValue() {
+        assertEquals(testStatus.getValue(), "CO");
+    }
+}


### PR DESCRIPTION
## Description

Add SG18 segment code to build segment objects from EDIFACT strings.

We have no examples of a segment group 18 in the EDIFACT files provided to us. But fortunately these segments exist in other segment groups.

e.g.
```
S02+02'
...
STS++UN'
```
```
S16+16'
...
INV+MQ+42R4.:911::Serum ferritin'
RSL+NV+11++:::ng/mL'
```

## Jira Ticket

https://gpitbjss.atlassian.net/browse/NIAD-873

## Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [x] Acceptance Criteria met
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] Self-reviewed your code
- [x] Code reviewed from two other developers
- [ ] If your pull request depends on any other, please link them in the description
- [ ] main branch is passing/green on CI
- [ ] Add/update any relevant documentation
