### PR TITLE
NIAD-966: Add mapping from edifact Requester to FHIR Practitioner

### DIFF
--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/inbound/fhir/EdifactToFhirService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/inbound/fhir/EdifactToFhirService.java
@@ -7,18 +7,18 @@ import org.hl7.fhir.dstu3.model.Parameters.ParametersParameterComponent;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Message;
-import uk.nhs.digital.nhsconnect.lab.results.translator.mapper.RequesterMapper;
+import uk.nhs.digital.nhsconnect.lab.results.translator.mapper.PractitionerMapper;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor(onConstructor_ = @Autowired)
 public class EdifactToFhirService {
-    private final RequesterMapper requesterMapper;
+    private final PractitionerMapper practitionerMapper;
 
     public Parameters convertToFhir(final Message message) {
         final var parameters = new Parameters();
 
-        requesterMapper.map(message)
+        practitionerMapper.mapRequester(message)
             .map(practitioner -> new ParametersParameterComponent().setResource(practitioner))
             .ifPresent(parameters::addParameter);
 

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/inbound/fhir/EdifactToFhirService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/inbound/fhir/EdifactToFhirService.java
@@ -3,18 +3,25 @@ package uk.nhs.digital.nhsconnect.lab.results.inbound.fhir;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.dstu3.model.Parameters;
+import org.hl7.fhir.dstu3.model.Parameters.ParametersParameterComponent;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Message;
+import uk.nhs.digital.nhsconnect.lab.results.translator.mapper.RequesterMapper;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor(onConstructor_ = @Autowired)
 public class EdifactToFhirService {
+    private final RequesterMapper requesterMapper;
 
     public Parameters convertToFhir(final Message message) {
-        //TODO: Replace this with actual mapping to FHIR
-        return new Parameters();
-    }
+        final var parameters = new Parameters();
 
+        requesterMapper.map(message)
+            .map(practitioner -> new ParametersParameterComponent().setResource(practitioner))
+            .ifPresent(parameters::addParameter);
+
+        return parameters;
+    }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/Message.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/Message.java
@@ -1,10 +1,11 @@
 package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
 
+import java.util.List;
+import java.util.Optional;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.List;
-
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class Message extends Section {
     private static final String DEFAULT_GP_CODE = "9999";
 
@@ -15,6 +16,11 @@ public class Message extends Section {
     @Getter(lazy = true)
     private final HealthAuthorityNameAndAddress healthAuthorityNameAndAddress =
         HealthAuthorityNameAndAddress.fromString(extractSegment(HealthAuthorityNameAndAddress.KEY_QUALIFIER));
+
+    @Getter(lazy = true)
+    private final Optional<RequesterNameAndAddress> requesterNameAndAddress =
+        extractOptionalSegment(RequesterNameAndAddress.KEY_QUALIFIER)
+            .map(RequesterNameAndAddress::fromString);
 
     @Getter
     @Setter

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RequesterNameAndAddress.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RequesterNameAndAddress.java
@@ -26,10 +26,10 @@ public class RequesterNameAndAddress extends Segment {
     private final String identifier;
     @NonNull
     private final HealthcareRegistrationIdentificationCode healthcareRegistrationIdentificationCode;
-    @NonNull
+
     private final String requesterName;
 
-    public static RequesterNameAndAddress fromString(String edifactString) {
+    public static RequesterNameAndAddress fromString(final String edifactString) {
         if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException("Can't create " + RequesterNameAndAddress.class.getSimpleName()
                 + " from " + edifactString);

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RequesterNameAndAddress.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RequesterNameAndAddress.java
@@ -43,7 +43,8 @@ public class RequesterNameAndAddress extends Segment {
         return new RequesterNameAndAddress(
             identifier,
             HealthcareRegistrationIdentificationCode.fromCode(code),
-            requesterName);
+            requesterName
+        );
     }
 
     @Override
@@ -70,16 +71,16 @@ public class RequesterNameAndAddress extends Segment {
     @Override
     public void preValidate() throws EdifactValidationException {
         if (identifier.isBlank()) {
-            throw new EdifactValidationException(getKey() + ": Attribute identifier is required");
+            throw new EdifactValidationException(KEY + ": Attribute identifier is required");
         }
 
         if (healthcareRegistrationIdentificationCode.getCode().isBlank()) {
             throw new EdifactValidationException(
-                getKey() + ": Attribute code in healthcareRegistrationIdentificationCode is required");
+                KEY + ": Attribute code in healthcareRegistrationIdentificationCode is required");
         }
 
         if (requesterName.isBlank()) {
-            throw new EdifactValidationException(getKey() + ": Attribute requesterName is required");
+            throw new EdifactValidationException(KEY + ": Attribute requesterName is required");
         }
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RequesterNameAndAddress.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RequesterNameAndAddress.java
@@ -19,7 +19,7 @@ public class RequesterNameAndAddress extends Segment {
 
     private static final String KEY = "NAD";
     private static final String QUALIFIER = "PO";
-    private static final String KEY_QUALIFIER = KEY + "+" + QUALIFIER;
+    public static final String KEY_QUALIFIER = KEY + PLUS_SEPARATOR + QUALIFIER;
     private static final int REQUESTER_NAME_INDEX_IN_EDIFACT_STRING = 4;
 
     @NonNull
@@ -31,7 +31,8 @@ public class RequesterNameAndAddress extends Segment {
 
     public static RequesterNameAndAddress fromString(String edifactString) {
         if (!edifactString.startsWith(KEY_QUALIFIER)) {
-            throw new IllegalArgumentException("Can't create " + RequesterNameAndAddress.class.getSimpleName() + " from " + edifactString);
+            throw new IllegalArgumentException("Can't create " + RequesterNameAndAddress.class.getSimpleName()
+                + " from " + edifactString);
         }
 
         String[] keySplit = Split.byPlus(edifactString);
@@ -39,7 +40,10 @@ public class RequesterNameAndAddress extends Segment {
         String code = Split.byColon(keySplit[2])[1];
         String requesterName = keySplit[REQUESTER_NAME_INDEX_IN_EDIFACT_STRING];
 
-        return new RequesterNameAndAddress(identifier, HealthcareRegistrationIdentificationCode.fromCode(code), requesterName);
+        return new RequesterNameAndAddress(
+            identifier,
+            HealthcareRegistrationIdentificationCode.fromCode(code),
+            requesterName);
     }
 
     @Override
@@ -49,12 +53,18 @@ public class RequesterNameAndAddress extends Segment {
 
     @Override
     public String getValue() {
-        return QUALIFIER + "+" + identifier + ":" + healthcareRegistrationIdentificationCode.getCode() + "++" + requesterName;
+        return QUALIFIER
+            + PLUS_SEPARATOR
+            + identifier
+            + COLON_SEPARATOR
+            + healthcareRegistrationIdentificationCode.getCode()
+            + PLUS_SEPARATOR + PLUS_SEPARATOR
+            + requesterName;
     }
 
     @Override
     protected void validateStateful() throws EdifactValidationException {
-
+        // no stateful fields to validate
     }
 
     @Override
@@ -64,7 +74,8 @@ public class RequesterNameAndAddress extends Segment {
         }
 
         if (healthcareRegistrationIdentificationCode.getCode().isBlank()) {
-            throw new EdifactValidationException(getKey() + ": Attribute code in healthcareRegistrationIdentificationCode is required");
+            throw new EdifactValidationException(
+                getKey() + ": Attribute code in healthcareRegistrationIdentificationCode is required");
         }
 
         if (requesterName.isBlank()) {

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PractitionerMapper.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PractitionerMapper.java
@@ -20,8 +20,8 @@ public class PractitionerMapper {
         result.addIdentifier()
             .setValue(requester.getIdentifier())
             .setSystem(SDS_USER_SYSTEM);
-        result.addName()
-            .setText(requester.getRequesterName());
+        Optional.ofNullable(requester.getRequesterName())
+            .ifPresent(name -> result.addName().setText(name));
         return result;
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PractitionerMapper.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PractitionerMapper.java
@@ -7,10 +7,10 @@ import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Message;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.RequesterNameAndAddress;
 
 @Component
-public class RequesterMapper {
+public class PractitionerMapper {
     protected static final String SDS_USER_SYSTEM = "https://fhir.nhs.uk/Id/sds-user-id";
 
-    public Optional<Practitioner> map(final Message message) {
+    public Optional<Practitioner> mapRequester(final Message message) {
         return message.getRequesterNameAndAddress()
             .map(this::toPractitioner);
     }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PractitionerMapper.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PractitionerMapper.java
@@ -8,7 +8,7 @@ import uk.nhs.digital.nhsconnect.lab.results.model.edifact.RequesterNameAndAddre
 
 @Component
 public class PractitionerMapper {
-    protected static final String SDS_USER_SYSTEM = "https://fhir.nhs.uk/Id/sds-user-id";
+    private static final String SDS_USER_SYSTEM = "https://fhir.nhs.uk/Id/sds-user-id";
 
     public Optional<Practitioner> mapRequester(final Message message) {
         return message.getRequesterNameAndAddress()

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/RequesterMapper.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/RequesterMapper.java
@@ -1,14 +1,27 @@
 package uk.nhs.digital.nhsconnect.lab.results.translator.mapper;
 
+import java.util.Optional;
 import org.hl7.fhir.dstu3.model.Practitioner;
 import org.springframework.stereotype.Component;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Message;
-
-import java.util.Optional;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.RequesterNameAndAddress;
 
 @Component
 public class RequesterMapper {
+    protected static final String SDS_USER_SYSTEM = "https://fhir.nhs.uk/Id/sds-user-id";
+
     public Optional<Practitioner> map(final Message message) {
-        return Optional.empty();
+        return message.getRequesterNameAndAddress()
+            .map(this::toPractitioner);
+    }
+
+    private Practitioner toPractitioner(final RequesterNameAndAddress requester) {
+        final var result = new Practitioner();
+        result.addIdentifier()
+            .setValue(requester.getIdentifier())
+            .setSystem(SDS_USER_SYSTEM);
+        result.addName()
+            .setText(requester.getRequesterName());
+        return result;
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/fhir/EdifactToFhirServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/fhir/EdifactToFhirServiceTest.java
@@ -13,13 +13,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Message;
-import uk.nhs.digital.nhsconnect.lab.results.translator.mapper.RequesterMapper;
+import uk.nhs.digital.nhsconnect.lab.results.translator.mapper.PractitionerMapper;
 
 @ExtendWith(MockitoExtension.class)
 class EdifactToFhirServiceTest {
 
     @Mock
-    private RequesterMapper requesterMapper;
+    private PractitionerMapper practitionerMapper;
 
     @Mock
     private Message message;
@@ -29,7 +29,7 @@ class EdifactToFhirServiceTest {
 
     @Test
     void testConvertEdifactToFhirRequesterMapperReturnsEmpty() {
-        when(requesterMapper.map(message)).thenReturn(Optional.empty());
+        when(practitionerMapper.mapRequester(message)).thenReturn(Optional.empty());
 
         final Parameters parameters = service.convertToFhir(message);
 
@@ -39,7 +39,7 @@ class EdifactToFhirServiceTest {
 
     @Test
     void testConvertEdifactToFhirRequesterMapperReturnsSomething() {
-        when(requesterMapper.map(message)).thenReturn(Optional.of(mock(Practitioner.class)));
+        when(practitionerMapper.mapRequester(message)).thenReturn(Optional.of(mock(Practitioner.class)));
 
         final Parameters parameters = service.convertToFhir(message);
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/fhir/EdifactToFhirServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/fhir/EdifactToFhirServiceTest.java
@@ -1,28 +1,53 @@
 package uk.nhs.digital.nhsconnect.lab.results.inbound.fhir;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
 import org.hl7.fhir.dstu3.model.Parameters;
+import org.hl7.fhir.dstu3.model.Practitioner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Message;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import uk.nhs.digital.nhsconnect.lab.results.translator.mapper.RequesterMapper;
 
 @ExtendWith(MockitoExtension.class)
 class EdifactToFhirServiceTest {
 
     @Mock
+    private RequesterMapper requesterMapper;
+
+    @Mock
     private Message message;
 
-    @Test
-    void testConvertEdifactToFhir() {
+    @InjectMocks
+    private EdifactToFhirService service;
 
-        final EdifactToFhirService service = new EdifactToFhirService();
+    @Test
+    void testConvertEdifactToFhirRequesterMapperReturnsEmpty() {
+        when(requesterMapper.map(message)).thenReturn(Optional.empty());
 
         final Parameters parameters = service.convertToFhir(message);
 
-        assertNotNull(parameters);
+        assertThat(parameters).isNotNull();
+        assertThat(parameters.getParameter()).isEmpty();
     }
 
+    @Test
+    void testConvertEdifactToFhirRequesterMapperReturnsSomething() {
+        when(requesterMapper.map(message)).thenReturn(Optional.of(mock(Practitioner.class)));
+
+        final Parameters parameters = service.convertToFhir(message);
+
+        assertThat(parameters).isNotNull();
+        assertThat(parameters.getParameter())
+            .hasSize(1)
+            .first()
+            .extracting(Parameters.ParametersParameterComponent::getResource)
+            .isNotNull();
+    }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PractitionerMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PractitionerMapperTest.java
@@ -58,7 +58,7 @@ class PractitionerMapperTest {
             .first()
             .satisfies(identifier -> assertAll(
                 () -> assertThat(identifier.getValue()).isEqualTo("Identifier"),
-                () -> assertThat(identifier.getSystem()).isEqualTo(PractitionerMapper.SDS_USER_SYSTEM)
+                () -> assertThat(identifier.getSystem()).isEqualTo("https://fhir.nhs.uk/Id/sds-user-id")
             ));
     }
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PractitionerMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PractitionerMapperTest.java
@@ -16,7 +16,7 @@ import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Message;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.RequesterNameAndAddress;
 
 @ExtendWith(MockitoExtension.class)
-class RequesterMapperTest {
+class PractitionerMapperTest {
 
     @Mock
     private Message message;
@@ -24,18 +24,18 @@ class RequesterMapperTest {
     @Mock
     private RequesterNameAndAddress requester;
 
-    private RequesterMapper mapper;
+    private PractitionerMapper mapper;
 
     @BeforeEach
     void setUp() {
-        mapper = new RequesterMapper();
+        mapper = new PractitionerMapper();
     }
 
     @Test
     void testMapMessageToPractitionerNoRequester() {
         when(message.getRequesterNameAndAddress()).thenReturn(Optional.empty());
 
-        assertThat(mapper.map(message)).isEmpty();
+        assertThat(mapper.mapRequester(message)).isEmpty();
     }
 
     @Test
@@ -44,7 +44,7 @@ class RequesterMapperTest {
         when(requester.getRequesterName()).thenReturn("Alan Turing");
         when(requester.getIdentifier()).thenReturn("Identifier");
 
-        Optional<Practitioner> result = mapper.map(message);
+        Optional<Practitioner> result = mapper.mapRequester(message);
         assertThat(result).isNotEmpty();
 
         Practitioner practitioner = result.get();
@@ -58,7 +58,7 @@ class RequesterMapperTest {
             .first()
             .satisfies(identifier -> assertAll(
                 () -> assertThat(identifier.getValue()).isEqualTo("Identifier"),
-                () -> assertThat(identifier.getSystem()).isEqualTo(RequesterMapper.SDS_USER_SYSTEM)
+                () -> assertThat(identifier.getSystem()).isEqualTo(PractitionerMapper.SDS_USER_SYSTEM)
             ));
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PractitionerMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PractitionerMapperTest.java
@@ -61,4 +61,15 @@ class PractitionerMapperTest {
                 () -> assertThat(identifier.getSystem()).isEqualTo(PractitionerMapper.SDS_USER_SYSTEM)
             ));
     }
+
+    @Test
+    void testMapMessageToPractitionerWithUnnamedRequester() {
+        when(message.getRequesterNameAndAddress()).thenReturn(Optional.of(requester));
+
+        Optional<Practitioner> result = mapper.mapRequester(message);
+        assertThat(result).isNotEmpty();
+
+        Practitioner practitioner = result.get();
+        assertThat(practitioner.getName()).isEmpty();
+    }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/RequesterMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/RequesterMapperTest.java
@@ -1,17 +1,64 @@
 package uk.nhs.digital.nhsconnect.lab.results.translator.mapper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.hl7.fhir.dstu3.model.HumanName;
+import org.hl7.fhir.dstu3.model.Practitioner;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Message;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.RequesterNameAndAddress;
 
-import java.util.ArrayList;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
+@ExtendWith(MockitoExtension.class)
 class RequesterMapperTest {
 
+    @Mock
+    private Message message;
+
+    @Mock
+    private RequesterNameAndAddress requester;
+
+    private RequesterMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new RequesterMapper();
+    }
+
     @Test
-    void testMapMessageToPractitioner() {
-        final Message message = new Message(new ArrayList<>());
-        assertTrue(new RequesterMapper().map(message).isEmpty());
+    void testMapMessageToPractitionerNoRequester() {
+        when(message.getRequesterNameAndAddress()).thenReturn(Optional.empty());
+
+        assertThat(mapper.map(message)).isEmpty();
+    }
+
+    @Test
+    void testMapMessageToPractitionerWithRequester() {
+        when(message.getRequesterNameAndAddress()).thenReturn(Optional.of(requester));
+        when(requester.getRequesterName()).thenReturn("Alan Turing");
+        when(requester.getIdentifier()).thenReturn("Identifier");
+
+        Optional<Practitioner> result = mapper.map(message);
+        assertThat(result).isNotEmpty();
+
+        Practitioner practitioner = result.get();
+        assertThat(practitioner.getName())
+            .hasSize(1)
+            .first()
+            .extracting(HumanName::getText)
+            .isEqualTo("Alan Turing");
+        assertThat(practitioner.getIdentifier())
+            .hasSize(1)
+            .first()
+            .satisfies(identifier -> assertAll(
+                () -> assertThat(identifier.getValue()).isEqualTo("Identifier"),
+                () -> assertThat(identifier.getSystem()).isEqualTo(RequesterMapper.SDS_USER_SYSTEM)
+            ));
     }
 }


### PR DESCRIPTION
## Description

The `RequesterMapper` now pulls out the relevant info from a `Message` to create a `Practitioner`, if possible. The `EdifactToFhirService` uses the `RequesterMapper` and if a `Practitioner` is indeed returned, adds it as a parameter to the outbound FHIR.

To verify this, I had to tweak the registration.dat contents to use `NAD+PO` instead of `NAD+GP`.

## Jira Ticket

https://gpitbjss.atlassian.net/browse/NIAD-966

## Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [x] Acceptance Criteria met
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] Self-reviewed your code
- [x] Code reviewed from two other developers
- [x] If your pull request depends on any other, please link them in the description
- [x] main branch is passing/green on CI
- [x] Add/update any relevant documentation
