### PR TITLE
NIAD-975: Rename `Specimen` to `SpecimenDetails`

### DIFF
--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/InvestigationSubject.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/InvestigationSubject.java
@@ -46,7 +46,7 @@ public class InvestigationSubject extends SegmentGroup {
     @Getter(lazy = true)
     private final PatientDetails details = new PatientDetails(getEdifactSegments().stream()
         .dropWhile(segment -> !segment.startsWith(PatientDetails.INDICATOR))
-        .takeWhile(segment -> !segment.startsWith(Specimen.INDICATOR))
+        .takeWhile(segment -> !segment.startsWith(SpecimenDetails.INDICATOR))
         .takeWhile(segment -> !segment.startsWith(MessageTrailer.KEY))
         .collect(toList()));
 
@@ -54,12 +54,12 @@ public class InvestigationSubject extends SegmentGroup {
     private final Optional<PatientClinicalInfo> clinicalInfo = PatientClinicalInfo.createOptional(
         getEdifactSegments().stream()
             .dropWhile(segment -> !segment.startsWith(PatientClinicalInfo.INDICATOR))
-            .takeWhile(segment -> !segment.startsWith(Specimen.INDICATOR))
+            .takeWhile(segment -> !segment.startsWith(SpecimenDetails.INDICATOR))
             .collect(toList()));
 
     @Getter(lazy = true)
-    private final List<Specimen> specimens = Specimen.createMultiple(getEdifactSegments().stream()
-        .dropWhile(segment -> !segment.startsWith(Specimen.INDICATOR))
+    private final List<SpecimenDetails> specimens = SpecimenDetails.createMultiple(getEdifactSegments().stream()
+        .dropWhile(segment -> !segment.startsWith(SpecimenDetails.INDICATOR))
         .takeWhile(segment -> !segment.startsWith(LabResult.INDICATOR))
         .takeWhile(segment -> !segment.startsWith(MessageTrailer.KEY))
         .collect(toList()));

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/SpecimenDetails.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/SpecimenDetails.java
@@ -41,7 +41,7 @@ import static uk.nhs.digital.nhsconnect.lab.results.model.edifact.Segment.PLUS_S
  * &gt; {@link InvestigationSubject}
  */
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-public class Specimen extends SegmentGroup {
+public class SpecimenDetails extends SegmentGroup {
     public static final String INDICATOR = "S16";
 
     @Getter(lazy = true)
@@ -90,13 +90,13 @@ public class Specimen extends SegmentGroup {
             .map(FreeTextSegment::fromString)
             .collect(Collectors.toList());
 
-    public static List<Specimen> createMultiple(@NonNull final List<String> edifactSegments) {
+    public static List<SpecimenDetails> createMultiple(@NonNull final List<String> edifactSegments) {
         return splitMultipleSegmentGroups(edifactSegments, INDICATOR).stream()
-            .map(Specimen::new)
+            .map(SpecimenDetails::new)
             .collect(Collectors.toList());
     }
 
-    public Specimen(final List<String> edifactSegments) {
+    public SpecimenDetails(final List<String> edifactSegments) {
         super(edifactSegments);
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/InvestigationSubjectTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/InvestigationSubjectTest.java
@@ -85,11 +85,11 @@ class InvestigationSubjectTest {
         assertAll(
             () -> assertThat(investigationSubject.getSpecimens()).hasSize(2)
                 .first()
-                .extracting(Specimen::getEdifactSegments)
+                .extracting(SpecimenDetails::getEdifactSegments)
                 .isEqualTo(List.of("S16+16", "specimen #1 contents")),
             () -> assertThat(investigationSubject.getSpecimens())
                 .last()
-                .extracting(Specimen::getEdifactSegments)
+                .extracting(SpecimenDetails::getEdifactSegments)
                 .isEqualTo(List.of("S16+16", "specimen #2 contents"))
         );
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/SpecimenDetailsTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/SpecimenDetailsTest.java
@@ -17,15 +17,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-class SpecimenTest {
+class SpecimenDetailsTest {
     @Test
     void testIndicator() {
-        assertThat(Specimen.INDICATOR).isEqualTo("S16");
+        assertThat(SpecimenDetails.INDICATOR).isEqualTo("S16");
     }
 
     @Test
     void testGetSequenceDetails() {
-        final var specimen = new Specimen(List.of(
+        final var specimen = new SpecimenDetails(List.of(
             "ignore me",
             "SEQ++123ABC",
             "ignore me"
@@ -38,7 +38,7 @@ class SpecimenTest {
 
     @Test
     void testGetSpecimenCharacteristicType() {
-        final var specimen = new Specimen(List.of(
+        final var specimen = new SpecimenDetails(List.of(
             "ignore me",
             "SPC+TSP+:::BLOOD & URINE",
             "ignore me"
@@ -51,7 +51,7 @@ class SpecimenTest {
 
     @Test
     void testGetSpecimenCharacteristicFastingStatus() {
-        final var specimen = new Specimen(List.of(
+        final var specimen = new SpecimenDetails(List.of(
             "ignore me",
             "SPC+FS+F",
             "ignore me"
@@ -64,7 +64,7 @@ class SpecimenTest {
 
     @Test
     void testGetSpecimenReferenceByServiceRequester() {
-        final var specimen = new Specimen(List.of(
+        final var specimen = new SpecimenDetails(List.of(
             "ignore me",
             "RFF+RTI:CH000064LX",
             "ignore me"
@@ -77,7 +77,7 @@ class SpecimenTest {
 
     @Test
     void testGetSpecimenReferenceByServiceProvider() {
-        final var specimen = new Specimen(List.of(
+        final var specimen = new SpecimenDetails(List.of(
             "ignore me",
             "RFF+STI:CH000064LX",
             "ignore me"
@@ -90,7 +90,7 @@ class SpecimenTest {
 
     @Test
     void testGetSpecimenQuantity() {
-        final var specimen = new Specimen(List.of(
+        final var specimen = new SpecimenDetails(List.of(
             "ignore me",
             "QTY+SVO:1750+:::mL",
             "ignore me"
@@ -103,7 +103,7 @@ class SpecimenTest {
 
     @Test
     void testGetSpecimenCollectionDateTime() {
-        final var specimen = new Specimen(List.of(
+        final var specimen = new SpecimenDetails(List.of(
             "ignore me",
             "DTM+SCO:20100223:102",
             "ignore me"
@@ -116,7 +116,7 @@ class SpecimenTest {
 
     @Test
     void testGetSpecimenCollectionReceiptDateTime() {
-        final var specimen = new Specimen(List.of(
+        final var specimen = new SpecimenDetails(List.of(
             "ignore me",
             "DTM+SRI:201002241541:203",
             "ignore me"
@@ -129,7 +129,7 @@ class SpecimenTest {
 
     @Test
     void testGetServiceProviderCommentFreeTexts() {
-        final var specimen = new Specimen(List.of(
+        final var specimen = new SpecimenDetails(List.of(
             "ignore me",
             "FTX+SPC+++red blood cell seen",
             "ignore me",
@@ -145,7 +145,7 @@ class SpecimenTest {
     @Test
     @SuppressWarnings("ResultOfMethodCallIgnored")
     void testLazyGettersWhenMissing() {
-        final var specimen = new Specimen(List.of());
+        final var specimen = new SpecimenDetails(List.of());
         assertAll(
             () -> assertThat(specimen.getSequenceDetails()).isEmpty(),
             () -> assertThatThrownBy(specimen::getCharacteristicType)


### PR DESCRIPTION
## Description

The hapifhir library already uses a `Specimen` type so
mapping from ours to theirs would need full package
qualification of one of them, which would be pretty ugly.

## Jira Ticket

https://gpitbjss.atlassian.net/browse/NIAD-975

## Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [x] Acceptance Criteria met
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] Self-reviewed your code
- [ ] Code reviewed from two other developers
- [x] If your pull request depends on any other, please link them in the description
- [x] main branch is passing/green on CI
- [x] Add/update any relevant documentation
