### PR TITLE
NIAD-1132: Apply consistent autoformatting rules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,7 @@ spotbugs {
 }
 
 checkstyle {
+	toolVersion = '8.41'
 	configFile = file("${rootDir}/config/checkstyle/checkstyle.xml")
 }
 

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/lab/results/IntegrationBaseTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/lab/results/IntegrationBaseTest.java
@@ -118,10 +118,10 @@ public abstract class IntegrationBaseTest {
 
     protected void waitForCondition(Supplier<Boolean> supplier) {
         await()
-            .atMost(WAIT_FOR_IN_SECONDS, SECONDS)
-            .pollInterval(POLL_INTERVAL_MS, MILLISECONDS)
-            .pollDelay(POLL_DELAY_MS, MILLISECONDS)
-            .until(supplier::get);
+                .atMost(WAIT_FOR_IN_SECONDS, SECONDS)
+                .pollInterval(POLL_INTERVAL_MS, MILLISECONDS)
+                .pollDelay(POLL_DELAY_MS, MILLISECONDS)
+                .until(supplier::get);
     }
 
     protected void clearMeshMailboxes() {
@@ -150,18 +150,18 @@ public abstract class IntegrationBaseTest {
     private MeshClient buildMeshClientForLabResultsMailbox() {
         // getting this from config is
         final String labResultsMailboxId = recipientMailboxIdMappings.getRecipientMailboxId(
-            new MeshMessage().setRecipient("XX11"));
+                new MeshMessage().setRecipient("XX11"));
         final String gpMailboxId = meshConfig.getMailboxId();
         final RecipientMailboxIdMappings mockRecipientMailboxIdMappings = mock(RecipientMailboxIdMappings.class);
         when(mockRecipientMailboxIdMappings.getRecipientMailboxId(any(OutboundMeshMessage.class)))
-            .thenReturn(gpMailboxId);
+                .thenReturn(gpMailboxId);
         // getters perform a transformation
         final String endpointCert = (String) FieldUtils.readField(meshConfig, "endpointCert", true);
         final String endpointPrivateKey = (String) FieldUtils.readField(meshConfig, "endpointPrivateKey", true);
         final String subCaCert = (String) FieldUtils.readField(meshConfig, "subCAcert", true);
         final MeshConfig labResultsMailboxConfig = new MeshConfig(labResultsMailboxId, meshConfig.getMailboxPassword(),
-            meshConfig.getSharedKey(), meshConfig.getHost(), meshConfig.getCertValidation(), endpointCert,
-            endpointPrivateKey, subCaCert);
+                meshConfig.getSharedKey(), meshConfig.getHost(), meshConfig.getCertValidation(), endpointCert,
+                endpointPrivateKey, subCaCert);
         final MeshHeaders meshHeaders = new MeshHeaders(labResultsMailboxConfig);
         final MeshRequests meshRequests = new MeshRequests(labResultsMailboxConfig, meshHeaders);
         return new MeshClient(meshRequests, mockRecipientMailboxIdMappings, meshHttpClientBuilder);
@@ -180,17 +180,17 @@ public abstract class IntegrationBaseTest {
     protected <T> T waitFor(Supplier<T> supplier) {
         var dataToReturn = new AtomicReference<T>();
         await()
-            .atMost(WAIT_FOR_IN_SECONDS, SECONDS)
-            .pollInterval(POLL_INTERVAL_MS, MILLISECONDS)
-            .pollDelay(POLL_DELAY_MS, MILLISECONDS)
-            .until(() -> {
-                var data = supplier.get();
-                if (data != null) {
-                    dataToReturn.set(data);
-                    return true;
-                }
-                return false;
-            });
+                .atMost(WAIT_FOR_IN_SECONDS, SECONDS)
+                .pollInterval(POLL_INTERVAL_MS, MILLISECONDS)
+                .pollDelay(POLL_DELAY_MS, MILLISECONDS)
+                .until(() -> {
+                    var data = supplier.get();
+                    if (data != null) {
+                        dataToReturn.set(data);
+                        return true;
+                    }
+                    return false;
+                });
 
         return dataToReturn.get();
     }

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/lab/results/container/ActiveMqContainer.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/lab/results/container/ActiveMqContainer.java
@@ -12,8 +12,8 @@ public final class ActiveMqContainer extends GenericContainer<ActiveMqContainer>
 
     private ActiveMqContainer() {
         super(new ImageFromDockerfile()
-            .withFileFromPath("activemq.xml", Path.of("./activemq/activemq.xml"))
-            .withFileFromPath("Dockerfile", Path.of("./activemq/Dockerfile"))
+                .withFileFromPath("activemq.xml", Path.of("./activemq/activemq.xml"))
+                .withFileFromPath("Dockerfile", Path.of("./activemq/Dockerfile"))
         );
         addExposedPort(ACTIVEMQ_PORT);
     }

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/lab/results/container/FakeMeshContainer.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/lab/results/container/FakeMeshContainer.java
@@ -14,7 +14,7 @@ public final class FakeMeshContainer extends GenericContainer<FakeMeshContainer>
 
     private FakeMeshContainer() {
         super(new ImageFromDockerfile()
-            .withFileFromPath("Dockerfile", Path.of("./fake-mesh/Dockerfile"))
+                .withFileFromPath("Dockerfile", Path.of("./fake-mesh/Dockerfile"))
         );
         addExposedPort(FAKE_MESH_PORT);
     }
@@ -29,7 +29,8 @@ public final class FakeMeshContainer extends GenericContainer<FakeMeshContainer>
     @Override
     public void start() {
         super.start();
-        var fakeMeshUri = "https://" + getContainerIpAddress() + ":" + getMappedPort(FAKE_MESH_PORT) + "/messageexchange/";
+        var fakeMeshUri =
+                "https://" + getContainerIpAddress() + ":" + getMappedPort(FAKE_MESH_PORT) + "/messageexchange/";
         LOGGER.info("Changing fake MESH URI (LAB_RESULTS_MESH_HOST) to {}", fakeMeshUri);
         System.setProperty("LAB_RESULTS_MESH_HOST", fakeMeshUri);
     }

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/lab/results/inbound/InboundMeshQueueMultiMessageTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/lab/results/inbound/InboundMeshQueueMultiMessageTest.java
@@ -53,8 +53,8 @@ public class InboundMeshQueueMultiMessageTest extends IntegrationBaseTest {
         final String content = new String(Files.readAllBytes(multiEdifactResource.getFile().toPath()));
 
         final MeshMessage meshMessage = new MeshMessage()
-            .setWorkflowId(WorkflowId.PATHOLOGY)
-            .setContent(content);
+                .setWorkflowId(WorkflowId.PATHOLOGY)
+                .setContent(content);
 
         sendToMeshInboundQueue(meshMessage);
 
@@ -64,7 +64,7 @@ public class InboundMeshQueueMultiMessageTest extends IntegrationBaseTest {
     @SuppressWarnings("checkstyle:magicnumber")
     private void assertGpOutboundQueueMessages(SoftAssertions softly) throws IOException, JMSException, JSONException {
         final List<Message> gpOutboundQueueMessages = List.of(getGpOutboundQueueMessage(), getGpOutboundQueueMessage(),
-            getGpOutboundQueueMessage());
+                getGpOutboundQueueMessage());
 
         assertGpOutboundQueueMessages(softly, gpOutboundQueueMessages.get(0), fhirMessage1);
         assertGpOutboundQueueMessages(softly, gpOutboundQueueMessages.get(1), fhirMessage2);
@@ -85,16 +85,16 @@ public class InboundMeshQueueMultiMessageTest extends IntegrationBaseTest {
         final String expectedMessageBody = new String(Files.readAllBytes(fhirMessage.getFile().toPath()));
 
         JSONAssert.assertEquals(
-            expectedMessageBody,
-            messageBody,
-            new CustomComparator(
-                JSONCompareMode.STRICT,
-                new Customization("meta.lastUpdated", IGNORE),
-                new Customization("identifier.value", IGNORE),
-                new Customization("entry[*].fullUrl", IGNORE),
-                new Customization("entry[*].resource.subject.reference", IGNORE),
-                new Customization("entry[*].resource.id", IGNORE)
-            )
+                expectedMessageBody,
+                messageBody,
+                new CustomComparator(
+                        JSONCompareMode.STRICT,
+                        new Customization("meta.lastUpdated", IGNORE),
+                        new Customization("identifier.value", IGNORE),
+                        new Customization("entry[*].fullUrl", IGNORE),
+                        new Customization("entry[*].resource.subject.reference", IGNORE),
+                        new Customization("entry[*].resource.id", IGNORE)
+                )
         );
     }
 

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/lab/results/inbound/InboundMeshQueueTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/lab/results/inbound/InboundMeshQueueTest.java
@@ -33,9 +33,9 @@ public class InboundMeshQueueTest extends IntegrationBaseTest {
     @Test
     void whenMeshInboundQueueMessageIsReceivedThenMessageIsHandled() throws IOException, JMSException, JSONException {
         final MeshMessage meshMessage = new MeshMessage()
-            .setWorkflowId(WorkflowId.PATHOLOGY)
-            .setContent(new String(Files.readAllBytes(getEdifactResource().getFile().toPath())))
-            .setMeshMessageId("12345");
+                .setWorkflowId(WorkflowId.PATHOLOGY)
+                .setContent(new String(Files.readAllBytes(getEdifactResource().getFile().toPath())))
+                .setMeshMessageId("12345");
 
         sendToMeshInboundQueue(meshMessage);
 
@@ -45,16 +45,16 @@ public class InboundMeshQueueTest extends IntegrationBaseTest {
         final String expectedContent = new String(Files.readAllBytes(getFhirResource().getFile().toPath()));
 
         JSONAssert.assertEquals(
-            expectedContent,
-            content,
-            new CustomComparator(
-                JSONCompareMode.STRICT,
-                new Customization("meta.lastUpdated", IGNORE),
-                new Customization("identifier.value", IGNORE),
-                new Customization("entry[*].fullUrl", IGNORE),
-                new Customization("entry[*].resource.subject.reference", IGNORE),
-                new Customization("entry[*].resource.id", IGNORE)
-            )
+                expectedContent,
+                content,
+                new CustomComparator(
+                        JSONCompareMode.STRICT,
+                        new Customization("meta.lastUpdated", IGNORE),
+                        new Customization("identifier.value", IGNORE),
+                        new Customization("entry[*].fullUrl", IGNORE),
+                        new Customization("entry[*].resource.subject.reference", IGNORE),
+                        new Customization("entry[*].resource.id", IGNORE)
+                )
         );
     }
 }

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/lab/results/inbound/InboundUserAcceptanceTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/lab/results/inbound/InboundUserAcceptanceTest.java
@@ -55,7 +55,7 @@ public class InboundUserAcceptanceTest extends IntegrationBaseTest {
         final String content = new String(Files.readAllBytes(getEdifactResource().getFile().toPath()));
 
         final OutboundMeshMessage outboundMeshMessage = OutboundMeshMessage.create(RECIPIENT,
-            WorkflowId.PATHOLOGY, content, null);
+                WorkflowId.PATHOLOGY, content, null);
 
         getLabResultsMeshClient().sendEdifactMessage(outboundMeshMessage);
 
@@ -69,16 +69,16 @@ public class InboundUserAcceptanceTest extends IntegrationBaseTest {
         final String messageBody = parseTextMessage(gpOutboundQueueMessage);
 
         JSONAssert.assertEquals(
-            expectedMessageBody,
-            messageBody,
-            new CustomComparator(
-                JSONCompareMode.STRICT,
-                new Customization("meta.lastUpdated", IGNORE),
-                new Customization("identifier.value", IGNORE),
-                new Customization("entry[*].fullUrl", IGNORE),
-                new Customization("entry[*].resource.subject.reference", IGNORE),
-                new Customization("entry[*].resource.id", IGNORE)
-            )
+                expectedMessageBody,
+                messageBody,
+                new CustomComparator(
+                        JSONCompareMode.STRICT,
+                        new Customization("meta.lastUpdated", IGNORE),
+                        new Customization("identifier.value", IGNORE),
+                        new Customization("entry[*].fullUrl", IGNORE),
+                        new Customization("entry[*].resource.subject.reference", IGNORE),
+                        new Customization("entry[*].resource.id", IGNORE)
+                )
         );
 
         //TODO: NIAD-1063 temporarily disabling NHSACK for v0.1
@@ -126,8 +126,8 @@ public class InboundUserAcceptanceTest extends IntegrationBaseTest {
         assertThat(edifactSegments).anySatisfy(segment -> assertThat(segment).startsWith("DTM+815"));
 
         return edifactSegments.stream()
-            .filter(segment -> !segment.startsWith("BGM+"))
-            .filter(segment -> !segment.startsWith("DTM+815"))
-            .collect(Collectors.toList());
+                .filter(segment -> !segment.startsWith("BGM+"))
+                .filter(segment -> !segment.startsWith("DTM+815"))
+                .collect(Collectors.toList());
     }
 }

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/lab/results/mesh/MeshClientIntegrationTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/lab/results/mesh/MeshClientIntegrationTest.java
@@ -45,7 +45,7 @@ class MeshClientIntegrationTest extends IntegrationBaseTest {
     private static final String RECIPIENT = "XX11";
     private static final String CONTENT = "test_message";
     private static final OutboundMeshMessage OUTBOUND_MESH_MESSAGE = OutboundMeshMessage.create(
-        RECIPIENT, WorkflowId.PATHOLOGY, CONTENT, null);
+            RECIPIENT, WorkflowId.PATHOLOGY, CONTENT, null);
     private static final String INVALID_WORKFLOW_ID = "INVALID";
 
     @Autowired
@@ -81,8 +81,8 @@ class MeshClientIntegrationTest extends IntegrationBaseTest {
         final MeshMessageId testMessageId = sendLargeMessageWithWrongWorkflowId();
 
         assertThatThrownBy(() -> getLabResultsMeshClient().getEdifactMessage(testMessageId.getMessageID()))
-            .isInstanceOf(MeshWorkflowUnknownException.class)
-            .hasMessageContaining(INVALID_WORKFLOW_ID);
+                .isInstanceOf(MeshWorkflowUnknownException.class)
+                .hasMessageContaining(INVALID_WORKFLOW_ID);
     }
 
     @SneakyThrows
@@ -113,7 +113,7 @@ class MeshClientIntegrationTest extends IntegrationBaseTest {
         final MeshMessageId testMessageId = getMeshClient().sendEdifactMessage(OUTBOUND_MESH_MESSAGE);
 
         assertThatCode(() -> getLabResultsMeshClient().acknowledgeMessage(testMessageId.getMessageID()))
-            .doesNotThrowAnyException();
+                .doesNotThrowAnyException();
     }
 
     @Test
@@ -136,7 +136,7 @@ class MeshClientIntegrationTest extends IntegrationBaseTest {
     @Test
     void when_downloadMessageThatDoesNotExist_expect_throwException() {
         assertThatExceptionOfType(MeshApiConnectionException.class).isThrownBy(
-            () -> getMeshClient().getEdifactMessage("thisisaninvalidmessageid1234567890")
+                () -> getMeshClient().getEdifactMessage("thisisaninvalidmessageid1234567890")
         );
     }
 
@@ -147,7 +147,7 @@ class MeshClientIntegrationTest extends IntegrationBaseTest {
         getLabResultsMeshClient().acknowledgeMessage(messageId);
 
         assertThatExceptionOfType(MeshApiConnectionException.class).isThrownBy(
-            () -> getMeshClient().getEdifactMessage(messageId)
+                () -> getMeshClient().getEdifactMessage(messageId)
         );
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/configuration/AmqpConfiguration.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/configuration/AmqpConfiguration.java
@@ -52,7 +52,7 @@ public class AmqpConfiguration {
 
     private void configureDeserializationPolicy(AmqpProperties properties, JmsConnectionFactory factory) {
         JmsDefaultDeserializationPolicy deserializationPolicy =
-            (JmsDefaultDeserializationPolicy) factory.getDeserializationPolicy();
+                (JmsDefaultDeserializationPolicy) factory.getDeserializationPolicy();
 
         if (hasLength(properties.getDeserializationPolicy().getWhiteList())) {
             deserializationPolicy.setAllowList(properties.getDeserializationPolicy().getWhiteList());
@@ -65,7 +65,7 @@ public class AmqpConfiguration {
 
     private void configureRedeliveryPolicy(AmqpProperties properties, JmsConnectionFactory factory) {
         factory.setRedeliveryPolicy(new CustomRedeliveryPolicy(
-            properties.getMaxRedeliveries(), JmsMessageSupport.MODIFIED_FAILED_UNDELIVERABLE));
+                properties.getMaxRedeliveries(), JmsMessageSupport.MODIFIED_FAILED_UNDELIVERABLE));
     }
 
     static class CustomRedeliveryPolicy implements JmsRedeliveryPolicy {

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/configuration/LabResultsMongoClientConfiguration.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/configuration/LabResultsMongoClientConfiguration.java
@@ -58,15 +58,15 @@ public class LabResultsMongoClientConfiguration extends AbstractMongoClientConfi
         LOGGER.info("Creating a connection string for mongo client settings...");
         if (!Strings.isNullOrEmpty(host)) {
             LOGGER.info("A value was provided from mongodb host. "
-                + "Generating a connection string from individual properties.");
+                    + "Generating a connection string from individual properties.");
             return createConnectionStringFromProperties();
         } else if (!Strings.isNullOrEmpty(uri)) {
             LOGGER.info("A mongodb connection string provided in spring.data.mongodb.uri "
-                + "and will be used to configure the database connection.");
+                    + "and will be used to configure the database connection.");
             return uri;
         } else {
             LOGGER.error("Mongodb must be configured using a connection string or individual properties. "
-                + "Both uri and host are null or empty");
+                    + "Both uri and host are null or empty");
             throw new RuntimeException("Missing mongodb connection string and/or properties");
         }
     }
@@ -86,7 +86,7 @@ public class LabResultsMongoClientConfiguration extends AbstractMongoClientConfi
             cs += "/?" + options;
         } else {
             LOGGER.warn("No options for the mongodb connection string were provided. "
-                + "If connecting to a cluster the driver may not work as expected.");
+                    + "If connecting to a cluster the driver may not work as expected.");
         }
         return cs;
     }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/inbound/EdifactParser.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/inbound/EdifactParser.java
@@ -82,7 +82,7 @@ public class EdifactParser {
                 messageTrailer.validate();
                 if (!messageHeader.getSequenceNumber().equals(messageTrailer.getSequenceNumber())) {
                     throw new EdifactValidationException(
-                        "Message header sequence number does not match trailer sequence number");
+                            "Message header sequence number does not match trailer sequence number");
                 }
                 message.setInterchange(interchange);
             });
@@ -90,44 +90,44 @@ public class EdifactParser {
         } catch (Exception ex) {
             var interchangeHeader = interchange.getInterchangeHeader();
             throw new MessagesParsingException(
-                "Error parsing messages",
-                interchangeHeader.getSender(),
-                interchangeHeader.getRecipient(),
-                interchangeHeader.getSequenceNumber(),
-                ex);
+                    "Error parsing messages",
+                    interchangeHeader.getSender(),
+                    interchangeHeader.getRecipient(),
+                    interchangeHeader.getSequenceNumber(),
+                    ex);
         }
 
         if (interchange.getInterchangeTrailer().getNumberOfMessages() != messages.size()) {
             var interchangeHeader = interchange.getInterchangeHeader();
             throw new InterchangeParsingException(
-                "Interchange trailer message count does not equal actual message count",
-                interchangeHeader.getSender(),
-                interchangeHeader.getRecipient(),
-                interchangeHeader.getSequenceNumber());
+                    "Interchange trailer message count does not equal actual message count",
+                    interchangeHeader.getSender(),
+                    interchangeHeader.getRecipient(),
+                    interchangeHeader.getSequenceNumber());
         }
     }
 
     private List<Message> parseAllMessages(List<String> allEdifactSegments) {
         var allMessageHeaderSegmentIndexes =
-            findAllIndexesOfSegment(allEdifactSegments, MessageHeader.KEY);
+                findAllIndexesOfSegment(allEdifactSegments, MessageHeader.KEY);
         var allMessageTrailerSegmentIndexes =
-            findAllIndexesOfSegment(allEdifactSegments, MessageTrailer.KEY);
+                findAllIndexesOfSegment(allEdifactSegments, MessageTrailer.KEY);
 
         var messageHeaderTrailerIndexPairs =
-            zipIndexes(allMessageHeaderSegmentIndexes, allMessageTrailerSegmentIndexes);
+                zipIndexes(allMessageHeaderSegmentIndexes, allMessageTrailerSegmentIndexes);
 
         return messageHeaderTrailerIndexPairs.stream()
-            .map(messageStartEndIndexPair -> allEdifactSegments.subList(
-                messageStartEndIndexPair.getLeft(), messageStartEndIndexPair.getRight() + 1))
-            .map(this::parseMessage)
-            .collect(Collectors.toList());
+                .map(messageStartEndIndexPair -> allEdifactSegments.subList(
+                        messageStartEndIndexPair.getLeft(), messageStartEndIndexPair.getRight() + 1))
+                .map(this::parseMessage)
+                .collect(Collectors.toList());
     }
 
     private Message parseMessage(List<String> singleMessageEdifactSegments) {
         var messageTrailerIndex = singleMessageEdifactSegments.size() - 1;
         var firstMessageEndIndex = findAllIndexesOfSegment(singleMessageEdifactSegments, MESSAGE_END_SEGMENT).stream()
-            .findFirst()
-            .orElse(messageTrailerIndex);
+                .findFirst()
+                .orElse(messageTrailerIndex);
 
         // first lines until end of message
         var onlyMessageLines = new ArrayList<>(singleMessageEdifactSegments.subList(0, firstMessageEndIndex));
@@ -139,11 +139,11 @@ public class EdifactParser {
     private List<Pair<Integer, Integer>> zipIndexes(List<Integer> startIndexes, List<Integer> endIndexes) {
         if (startIndexes.size() != endIndexes.size()) {
             throw new ToEdifactParsingException(
-                "Message header-trailer count mismatch: " + startIndexes.size() + "-" + endIndexes.size());
+                    "Message header-trailer count mismatch: " + startIndexes.size() + "-" + endIndexes.size());
         }
 
         var indexPairs = Streams.zip(startIndexes.stream(), endIndexes.stream(), Pair::of)
-            .collect(Collectors.toList());
+                .collect(Collectors.toList());
 
         if (!areIndexesInOrder(indexPairs)) {
             throw new ToEdifactParsingException("Message trailer before message header");
@@ -156,11 +156,11 @@ public class EdifactParser {
         // trailer must go after header
         // next header must go after previous trailer
         return Comparators.isInOrder(
-            messageIndexPairs.stream()
-                .map(pair -> List.of(pair.getLeft(), pair.getRight()))
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList()),
-            Comparator.naturalOrder());
+                messageIndexPairs.stream()
+                        .map(pair -> List.of(pair.getLeft(), pair.getRight()))
+                        .flatMap(Collection::stream)
+                        .collect(Collectors.toList()),
+                Comparator.naturalOrder());
     }
 
     private List<String> extractInterchangeEdifactSegments(List<String> allEdifactSegments) {
@@ -170,17 +170,17 @@ public class EdifactParser {
 
         var segmentsBeforeFirstMessageHeader = allEdifactSegments.subList(0, firstMessageHeaderIndex);
         var segmentsAfterLastMessageTrailer = allEdifactSegments.subList(
-            lastMessageTrailerIndex + 1, allEdifactSegments.size());
+                lastMessageTrailerIndex + 1, allEdifactSegments.size());
 
         return Stream.of(segmentsBeforeFirstMessageHeader, segmentsAfterLastMessageTrailer)
-            .flatMap(Collection::stream)
-            .collect(Collectors.toList());
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
     }
 
     private List<Integer> findAllIndexesOfSegment(List<String> list, String key) {
         return IntStream.range(0, list.size())
-            .filter(i -> list.get(i).startsWith(key))
-            .boxed()
-            .collect(Collectors.toList());
+                .filter(i -> list.get(i).startsWith(key))
+                .boxed()
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/inbound/InboundMessageHandler.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/inbound/InboundMessageHandler.java
@@ -50,15 +50,15 @@ public class InboundMessageHandler {
         final List<MessageProcessingResult> messageProcessingResults = getFhirDataToSend(interchange.getMessages());
 
         var nhsack = outboundMeshMessageBuilder.buildNhsAck(
-            meshMessage.getWorkflowId(),
-            interchange,
-            messageProcessingResults);
+                meshMessage.getWorkflowId(),
+                interchange,
+                messageProcessingResults);
 
         messageProcessingResults.stream()
-            .filter(MessageProcessingResult.Success.class::isInstance)
-            .map(MessageProcessingResult.Success.class::cast)
-            .map(MessageProcessingResult.Success::getBundle)
-            .forEach(gpOutboundQueueService::publish);
+                .filter(MessageProcessingResult.Success.class::isInstance)
+                .map(MessageProcessingResult.Success.class::cast)
+                .map(MessageProcessingResult.Success::getBundle)
+                .forEach(gpOutboundQueueService::publish);
 
         logSentFor(interchange);
 
@@ -69,8 +69,8 @@ public class InboundMessageHandler {
 
     private List<MessageProcessingResult> getFhirDataToSend(List<Message> messages) {
         return messages.stream()
-            .map(this::convertToFhir)
-            .collect(Collectors.toList());
+                .map(this::convertToFhir)
+                .collect(Collectors.toList());
     }
 
     private MessageProcessingResult convertToFhir(Message message) {
@@ -88,8 +88,8 @@ public class InboundMessageHandler {
         if (LOGGER.isInfoEnabled()) {
             final InterchangeHeader interchangeHeader = interchange.getInterchangeHeader();
             LOGGER.info("Translating EDIFACT interchange from Sender={} to Recipient={} with RIS={} "
-                    + "containing {} messages", interchangeHeader.getSender(), interchangeHeader.getRecipient(),
-                interchangeHeader.getSequenceNumber(), interchange.getMessages().size());
+                            + "containing {} messages", interchangeHeader.getSender(), interchangeHeader.getRecipient(),
+                    interchangeHeader.getSequenceNumber(), interchange.getMessages().size());
         }
     }
 
@@ -97,8 +97,8 @@ public class InboundMessageHandler {
         if (LOGGER.isInfoEnabled()) {
             final InterchangeHeader interchangeHeader = interchange.getInterchangeHeader();
             LOGGER.info("Published FHIR for the interchange from Sender={} to Recipient={} with RIS={}",
-                interchangeHeader.getSender(), interchangeHeader.getRecipient(),
-                interchangeHeader.getSequenceNumber());
+                    interchangeHeader.getSender(), interchangeHeader.getRecipient(),
+                    interchangeHeader.getSequenceNumber());
         }
     }
 
@@ -106,8 +106,8 @@ public class InboundMessageHandler {
         if (LOGGER.isInfoEnabled()) {
             final var header = interchange.getInterchangeHeader();
             LOGGER.info("Published for async send to MESH an NHSACK for the interchange from "
-                    + "Sender={} to Recipient={} with RIS={}",
-                header.getSender(), header.getRecipient(), header.getSequenceNumber());
+                            + "Sender={} to Recipient={} with RIS={}",
+                    header.getSender(), header.getRecipient(), header.getSequenceNumber());
         }
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/inbound/queue/MeshInboundQueueService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/inbound/queue/MeshInboundQueueService.java
@@ -52,7 +52,7 @@ public class MeshInboundQueueService {
             final WorkflowId workflowId = meshMessage.getWorkflowId();
 
             LOGGER.info("Processing MeshMessageId={} with MeshWorkflowId={}", meshMessage.getMeshMessageId(),
-                workflowId);
+                    workflowId);
 
             if (WorkflowId.PATHOLOGY.equals(workflowId)) {
                 inboundMessageHandler.handle(meshMessage);

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/MeshMailBoxScheduler.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/MeshMailBoxScheduler.java
@@ -32,6 +32,6 @@ public class MeshMailBoxScheduler {
 
     private boolean updateTimestamp(long seconds) {
         return schedulerTimestampRepository.updateTimestamp(
-            SCHEDULER_TYPE, timestampService.getCurrentTimestamp(), seconds);
+                SCHEDULER_TYPE, timestampService.getCurrentTimestamp(), seconds);
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/MeshService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/MeshService.java
@@ -35,13 +35,13 @@ public class MeshService {
 
     @Autowired
     public MeshService(
-        MeshClient meshClient,
-        MeshInboundQueueService meshInboundQueueService,
-        MeshMailBoxScheduler meshMailBoxScheduler,
-        CorrelationIdService correlationIdService,
-        @Value("${labresults.mesh.pollingCycleMinimumIntervalInSeconds}") long pollingCycleMinimumIntervalInSeconds,
-        @Value("${labresults.mesh.wakeupIntervalInMilliseconds}") long wakeupIntervalInMilliseconds,
-        @Value("${labresults.mesh.pollingCycleDurationInSeconds}") long pollingCycleDurationInSeconds
+            MeshClient meshClient,
+            MeshInboundQueueService meshInboundQueueService,
+            MeshMailBoxScheduler meshMailBoxScheduler,
+            CorrelationIdService correlationIdService,
+            @Value("${labresults.mesh.pollingCycleMinimumIntervalInSeconds}") long pollingCycleMinimumIntervalInSeconds,
+            @Value("${labresults.mesh.wakeupIntervalInMilliseconds}") long wakeupIntervalInMilliseconds,
+            @Value("${labresults.mesh.pollingCycleDurationInSeconds}") long pollingCycleDurationInSeconds
     ) {
         this.meshClient = meshClient;
         this.meshInboundQueueService = meshInboundQueueService;
@@ -56,7 +56,7 @@ public class MeshService {
     public void scanMeshInboxForMessages() {
         if (!meshMailBoxScheduler.isEnabled()) {
             LOGGER.warn("Not running the MESH mailbox polling cycle because it is disabled. Set variable "
-                + "LAB_RESULTS_SCHEDULER_ENABLED to true to enable it.");
+                    + "LAB_RESULTS_SCHEDULER_ENABLED to true to enable it.");
             return;
         }
         LOGGER.info("Requesting lock from database to run MESH mailbox polling cycle");
@@ -70,16 +70,16 @@ public class MeshService {
                     processSingleMessage(messageId);
                 } else {
                     LOGGER.warn("Insufficient time remains to complete the polling cycle. "
-                        + "Processed {} of {} messages from inbox.", i + 1, inboxMessageIds.size());
+                            + "Processed {} of {} messages from inbox.", i + 1, inboxMessageIds.size());
                     return;
                 }
             }
             LOGGER.info("Completed MESH mailbox polling cycle. Processed all messages from inbox.");
         } else {
             LOGGER.info("Could not obtain database lock to run MESH mailbox polling cycle: insufficient time has "
-                    + "elapsed since the previous polling cycle or another adaptor instance has already "
-                    + "started the polling cycle. Next scan in {} seconds",
-                TimeUnit.MILLISECONDS.toSeconds(wakeupIntervalInMilliseconds));
+                            + "elapsed since the previous polling cycle or another adaptor instance has already "
+                            + "started the polling cycle. Next scan in {} seconds",
+                    TimeUnit.MILLISECONDS.toSeconds(wakeupIntervalInMilliseconds));
         }
     }
 
@@ -108,7 +108,7 @@ public class MeshService {
             LOGGER.info("Published MeshMessageId={} for inbound processing", meshMessage.getMeshMessageId());
         } catch (MeshWorkflowUnknownException ex) {
             LOGGER.warn("MeshMessageId={} has an unsupported MeshWorkflowId={} and has been left in the inbox.",
-                messageId, ex.getWorkflowId());
+                    messageId, ex.getWorkflowId());
         } catch (Exception ex) {
             LOGGER.error("Error during reading of MESH message. MeshMessageId={}", messageId, ex);
             // skip message with error and attempt to download the next one

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/RecipientMailboxIdMappings.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/RecipientMailboxIdMappings.java
@@ -16,7 +16,7 @@ public class RecipientMailboxIdMappings {
 
     @Autowired
     public RecipientMailboxIdMappings(
-        @Value("${labresults.mesh.recipientToMailboxIdMappings}") String recipientToMailboxIdMappings
+            @Value("${labresults.mesh.recipientToMailboxIdMappings}") String recipientToMailboxIdMappings
     ) {
         this.recipientToMailboxIdMappings = recipientToMailboxIdMappings;
     }
@@ -33,15 +33,15 @@ public class RecipientMailboxIdMappings {
 
     private Map<String, String> createMappings() {
         return Stream.of(recipientToMailboxIdMappings.split(" "))
-            .map(row -> row.split("="))
-            .peek(this::validateMappings)
-            .collect(Collectors.toMap(row -> row[0].strip(), row -> row[1].strip()));
+                .map(row -> row.split("="))
+                .peek(this::validateMappings)
+                .collect(Collectors.toMap(row -> row[0].strip(), row -> row[1].strip()));
     }
 
     private void validateMappings(String[] rows) {
         if (rows.length < 2) {
             throw new MeshRecipientUnknownException("LAB_RESULTS_MESH_RECIPIENT_MAILBOX_ID_MAPPINGS "
-                + "env var doesn't contain valid recipient to mailbox mapping");
+                    + "env var doesn't contain valid recipient to mailbox mapping");
         }
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/exception/MeshApiConnectionException.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/exception/MeshApiConnectionException.java
@@ -7,7 +7,7 @@ public class MeshApiConnectionException extends LabResultsBaseException {
 
     public MeshApiConnectionException(String description, HttpStatus expectedStatus, HttpStatus actualStatus) {
         super(description + " Expected status code: " + expectedStatus.value()
-            + ", but received: " + actualStatus.value());
+                + ", but received: " + actualStatus.value());
     }
 
     public MeshApiConnectionException(String description,
@@ -15,7 +15,7 @@ public class MeshApiConnectionException extends LabResultsBaseException {
                                       HttpStatus actualStatus,
                                       String content) {
         super(description + " Expected status code: " + expectedStatus.value()
-            + ", but received: " + actualStatus.value() + " with response content\n" + content);
+                + ", but received: " + actualStatus.value() + " with response content\n" + content);
     }
 
     public MeshApiConnectionException(String message) {

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/http/MeshClient.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/http/MeshClient.java
@@ -47,8 +47,8 @@ public class MeshClient {
                 logResponse(loggingName, response);
                 if (response.getStatusLine().getStatusCode() != HttpStatus.OK.value()) {
                     throw new MeshApiConnectionException("Couldn't authenticate to MESH.",
-                        HttpStatus.OK,
-                        HttpStatus.valueOf(response.getStatusLine().getStatusCode()));
+                            HttpStatus.OK,
+                            HttpStatus.valueOf(response.getStatusLine().getStatusCode()));
                 }
             }
         }
@@ -59,7 +59,7 @@ public class MeshClient {
         final var loggingName = "Send a message";
         final String recipientMailbox = recipientMailboxIdMappings.getRecipientMailboxId(outboundMeshMessage);
         LOGGER.info("Sending to MESH API: recipient: {}, MESH mailbox: {}, workflow: {}",
-            outboundMeshMessage.getRecipient(), recipientMailbox, outboundMeshMessage.getWorkflowId());
+                outboundMeshMessage.getRecipient(), recipientMailbox, outboundMeshMessage.getWorkflowId());
         try (CloseableHttpClient client = meshHttpClientBuilder.build()) {
             final var request = meshRequests.sendMessage(recipientMailbox, outboundMeshMessage.getWorkflowId());
             final String contentString = outboundMeshMessage.getContent();
@@ -72,13 +72,13 @@ public class MeshClient {
                     // safe to get content in case of error
                     final String content = EntityUtils.toString(response.getEntity());
                     throw new MeshApiConnectionException("Couldn't send MESH message.",
-                        HttpStatus.ACCEPTED,
-                        HttpStatus.valueOf(response.getStatusLine().getStatusCode()),
-                        content);
+                            HttpStatus.ACCEPTED,
+                            HttpStatus.valueOf(response.getStatusLine().getStatusCode()),
+                            content);
                 }
                 final MeshMessageId meshMessageId = parseInto(MeshMessageId.class, response, loggingName);
                 LOGGER.info("Successfully sent message MeshMailboxId={} in MeshMessageId={}",
-                    recipientMailbox, meshMessageId.getMessageID());
+                        recipientMailbox, meshMessageId.getMessageID());
                 return meshMessageId;
             }
         }
@@ -96,9 +96,9 @@ public class MeshClient {
                     // safe to get content in case of error
                     final String content = EntityUtils.toString(response.getEntity());
                     throw new MeshApiConnectionException("Couldn't download MeshMessageId=" + messageId,
-                        HttpStatus.OK,
-                        HttpStatus.valueOf(response.getStatusLine().getStatusCode()),
-                        content);
+                            HttpStatus.OK,
+                            HttpStatus.valueOf(response.getStatusLine().getStatusCode()),
+                            content);
                 }
                 final var meshMessage = new MeshMessage();
                 /* Get the workflowId before extracting the message body. An exception is thrown if the workflowId is
@@ -123,8 +123,8 @@ public class MeshClient {
                 if (response.getStatusLine().getStatusCode() != HttpStatus.OK.value()) {
                     logResponse(loggingName, response);
                     throw new MeshApiConnectionException("Couldn't acknowledge MESH message using id: " + messageId,
-                        HttpStatus.OK,
-                        HttpStatus.valueOf(response.getStatusLine().getStatusCode()));
+                            HttpStatus.OK,
+                            HttpStatus.valueOf(response.getStatusLine().getStatusCode()));
                 }
             }
         }
@@ -140,8 +140,8 @@ public class MeshClient {
                 logResponse(loggingName, response);
                 if (response.getStatusLine().getStatusCode() != HttpStatus.OK.value()) {
                     throw new MeshApiConnectionException("Couldn't receive MESH message list",
-                        HttpStatus.OK,
-                        HttpStatus.valueOf(response.getStatusLine().getStatusCode()));
+                            HttpStatus.OK,
+                            HttpStatus.valueOf(response.getStatusLine().getStatusCode()));
                 }
                 final var meshMessages = parseInto(MeshMessages.class, response, loggingName);
                 return Arrays.asList(meshMessages.getMessageIDs());
@@ -181,7 +181,7 @@ public class MeshClient {
         if (LOGGER.isDebugEnabled() && response.getEntity() != null) {
             final var entity = response.getEntity();
             LOGGER.debug("MESH '{}' response content encoding: {}, content type: {}, content length: {}",
-                type, entity.getContentEncoding(), entity.getContentType(), entity.getContentLength());
+                    type, entity.getContentEncoding(), entity.getContentType(), entity.getContentLength());
             // response is usually not "repeatable" so we can only decode it once. Log response content separately.
         }
     }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/http/MeshHeaders.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/http/MeshHeaders.java
@@ -40,7 +40,7 @@ public class MeshHeaders {
 
     public Header[] createMinimalHeaders() {
         final List<BasicHeader> authorization = List.of(
-            new BasicHeader("Authorization", new MeshAuthorizationToken(meshConfig).getValue()));
+                new BasicHeader("Authorization", new MeshAuthorizationToken(meshConfig).getValue()));
         return Stream.concat(OS_HEADERS.stream(), authorization.stream())
                 .toArray(Header[]::new);
     }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/http/MeshRequests.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/http/MeshRequests.java
@@ -42,7 +42,7 @@ public class MeshRequests {
 
     public HttpPut acknowledge(String messageId) {
         final var request = new HttpPut(meshConfig.getHost() + meshConfig.getMailboxId() + "/inbox/"
-            + messageId + "/status/acknowledged");
+                + messageId + "/status/acknowledged");
         request.setHeaders(meshHeaders.createMinimalHeaders());
         return request;
     }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/http/SSLContextBuilder.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/http/SSLContextBuilder.java
@@ -50,9 +50,9 @@ public class SSLContextBuilder {
         tmf.init(ts);
 
         SSLContext sslContext = SSLContexts.custom()
-            .loadKeyMaterial(ks, meshConfig.getMailboxPassword().toCharArray())
-            .loadTrustMaterial(TrustSelfSignedStrategy.INSTANCE)
-            .build();
+                .loadKeyMaterial(ks, meshConfig.getMailboxPassword().toCharArray())
+                .loadTrustMaterial(TrustSelfSignedStrategy.INSTANCE)
+                .build();
 
         sslContext.init(keyManagerFactory.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
 
@@ -62,23 +62,23 @@ public class SSLContextBuilder {
     @SneakyThrows
     private SSLContext noValidationSSLContext() {
         return SSLContexts.custom()
-            .loadKeyMaterial(buildKeyStore(meshConfig), meshConfig.getMailboxPassword().toCharArray())
-            .loadTrustMaterial(TrustAllStrategy.INSTANCE)
-            .build();
+                .loadKeyMaterial(buildKeyStore(meshConfig), meshConfig.getMailboxPassword().toCharArray())
+                .loadTrustMaterial(TrustAllStrategy.INSTANCE)
+                .build();
     }
 
     @SneakyThrows
     private static KeyStore buildKeyStore(MeshConfig meshConfig) {
         return EnvKeyStore.createFromPEMStrings(
-            meshConfig.getEndpointPrivateKey(),
-            meshConfig.getEndpointCert(),
-            meshConfig.getMailboxPassword()).keyStore();
+                meshConfig.getEndpointPrivateKey(),
+                meshConfig.getEndpointCert(),
+                meshConfig.getMailboxPassword()).keyStore();
     }
 
     @SneakyThrows
     private static KeyStore buildTrustStore(MeshConfig meshConfig) {
         return EnvKeyStore.createFromPEMStrings(
-            meshConfig.getSubCAcert(),
-            meshConfig.getMailboxPassword()).keyStore();
+                meshConfig.getSubCAcert(),
+                meshConfig.getMailboxPassword()).keyStore();
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/message/InboundMeshMessage.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/message/InboundMeshMessage.java
@@ -5,9 +5,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public interface InboundMeshMessage {
     WorkflowId getWorkflowId();
+
     String getContent();
+
     String getMessageSentTimestamp();
+
     InboundMeshMessage setMessageSentTimestamp(String timestamp);
+
     String getMeshMessageId();
 
     @JsonCreator

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/message/OutboundMeshMessage.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/message/OutboundMeshMessage.java
@@ -5,9 +5,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public interface OutboundMeshMessage {
     String getRecipient();
+
     WorkflowId getWorkflowId();
+
     String getContent();
+
     String getMessageSentTimestamp();
+
     OutboundMeshMessage setMessageSentTimestamp(String timestamp);
 
     @JsonCreator

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/message/WorkflowId.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/message/WorkflowId.java
@@ -25,8 +25,9 @@ public enum WorkflowId {
 
     public static WorkflowId fromString(String workflowId) {
         return Arrays.stream(WorkflowId.values())
-            .filter(workflow -> workflow.workflowId.equalsIgnoreCase(workflowId))
-            .findFirst()
-            .orElseThrow(() -> new MeshWorkflowUnknownException("Unsupported workflow id " + workflowId, workflowId));
+                .filter(workflow -> workflow.workflowId.equalsIgnoreCase(workflowId))
+                .findFirst()
+                .orElseThrow(
+                        () -> new MeshWorkflowUnknownException("Unsupported workflow id " + workflowId, workflowId));
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/scheduler/SchedulerTimestamp.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/scheduler/SchedulerTimestamp.java
@@ -7,12 +7,11 @@ import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.Instant;
 
-@CompoundIndexes({
-    @CompoundIndex(
+@CompoundIndexes(@CompoundIndex(
         name = "unique_document",
         def = "{'schedulerType': 1}",
         unique = true)
-})
+)
 @Data
 @Document
 public class SchedulerTimestamp {

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/scheduler/SchedulerTimestampRepository.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/scheduler/SchedulerTimestampRepository.java
@@ -5,5 +5,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SchedulerTimestampRepository
-    extends CrudRepository<SchedulerTimestamp, String>, SchedulerTimestampRepositoryExtensions {
+        extends CrudRepository<SchedulerTimestamp, String>, SchedulerTimestampRepositoryExtensions {
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/scheduler/SchedulerTimestampRepositoryExtensionsImpl.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/scheduler/SchedulerTimestampRepositoryExtensionsImpl.java
@@ -31,11 +31,11 @@ public class SchedulerTimestampRepositoryExtensionsImpl implements SchedulerTime
     @Override
     public boolean updateTimestamp(String schedulerType, Instant timestamp, long seconds) {
         final var query = query(where(TIMESTAMP_FIELD_NAME)
-            .lt(timestampService.getCurrentTimestamp().minusSeconds(seconds))
-            .and(SCHEDULER_TYPE).is(schedulerType));
+                .lt(timestampService.getCurrentTimestamp().minusSeconds(seconds))
+                .and(SCHEDULER_TYPE).is(schedulerType));
 
         final var update = Update.update(TIMESTAMP_FIELD_NAME, timestamp)
-            .set(SCHEDULER_TYPE, schedulerType);
+                .set(SCHEDULER_TYPE, schedulerType);
 
         if (documentAlreadyExists(schedulerType)) {
             final UpdateResult result = mongoOperations.updateFirst(query, update, MESH_TIMESTAMP_COLLECTION_NAME);
@@ -43,14 +43,14 @@ public class SchedulerTimestampRepositoryExtensionsImpl implements SchedulerTime
             return updateSuccessful(result);
         } else {
             LOGGER.info("{} collection does not exist or it is empty. Document with timestamp will be created",
-                MESH_TIMESTAMP_COLLECTION_NAME);
+                    MESH_TIMESTAMP_COLLECTION_NAME);
             final SchedulerTimestamp schedulerTimestamp = new SchedulerTimestamp(
-                schedulerType, timestampService.getCurrentTimestamp());
+                    schedulerType, timestampService.getCurrentTimestamp());
             try {
                 mongoOperations.save(schedulerTimestamp, MESH_TIMESTAMP_COLLECTION_NAME);
             } catch (MongoWriteException | DuplicateKeyException e) {
                 LOGGER.warn("Unable to create new document for scheduler type {}. "
-                    + "Most likely another instance already created the document.", schedulerType, e);
+                        + "Most likely another instance already created the document.", schedulerType, e);
             }
             return false;
         }
@@ -62,7 +62,7 @@ public class SchedulerTimestampRepositoryExtensionsImpl implements SchedulerTime
         final var count = mongoOperations.count(query, MESH_TIMESTAMP_COLLECTION_NAME);
         if (count > 1) {
             LOGGER.error("More than one document exists for schedulerType {}. "
-                + "This can cause unexpected scheduling behaviour.", schedulerType);
+                    + "This can cause unexpected scheduling behaviour.", schedulerType);
         }
         return count >= 1;
     }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/token/AuthorizationHashGenerator.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/token/AuthorizationHashGenerator.java
@@ -15,11 +15,11 @@ class AuthorizationHashGenerator {
     @SneakyThrows
     public String computeHash(MeshConfig meshConfig, Nonce nonce, String timestamp) {
         final String hashInput = String.join(":", meshConfig.getMailboxId(), nonce.getValue(), Nonce.COUNT,
-            meshConfig.getMailboxPassword(), timestamp);
+                meshConfig.getMailboxPassword(), timestamp);
 
         final Mac sha256Hmac = Mac.getInstance(HMAC_SHA256_ALGORITHM_NAME);
         final SecretKeySpec secretKey = new SecretKeySpec(meshConfig.getSharedKey().getBytes(StandardCharsets.UTF_8),
-            HMAC_SHA256_ALGORITHM_NAME);
+                HMAC_SHA256_ALGORITHM_NAME);
         sha256Hmac.init(secretKey);
 
         return Hex.encodeHexString(sha256Hmac.doFinal(hashInput.getBytes(StandardCharsets.UTF_8)));

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/token/MeshAuthorizationToken.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/mesh/token/MeshAuthorizationToken.java
@@ -16,7 +16,7 @@ public class MeshAuthorizationToken {
     private final String hash;
 
     public MeshAuthorizationToken(MeshConfig meshConfig, Instant timestamp, Nonce nonce,
-        AuthorizationHashGenerator authorizationHashGenerator) {
+                                  AuthorizationHashGenerator authorizationHashGenerator) {
         final String prefix = MESSAGE_TYPE + meshConfig.getMailboxId();
         final String currentTimeFormatted = new TokenTimestamp(timestamp).getValue();
         this.data = String.join(":", prefix, nonce.getValue(), Nonce.COUNT, currentTimeFormatted);

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ClinicalInformationCode.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ClinicalInformationCode.java
@@ -22,7 +22,7 @@ public class ClinicalInformationCode extends Segment {
     public static ClinicalInformationCode fromString(final String edifactString) {
         if (!edifactString.startsWith(KEY)) {
             throw new IllegalArgumentException("Can't create " + ClinicalInformationCode.class.getSimpleName()
-                + " from " + edifactString);
+                    + " from " + edifactString);
         }
         final String[] keySplit = Split.byPlus(edifactString);
         final String code = keySplit[1];

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DateFormat.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DateFormat.java
@@ -19,8 +19,8 @@ public enum DateFormat {
 
     public static DateFormat fromCode(final String code) {
         return Arrays.stream(DateFormat.values())
-            .filter(dateFormat -> dateFormat.code.equals(code))
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("No dateFormat name for '" + code + "'"));
+                .filter(dateFormat -> dateFormat.code.equals(code))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No dateFormat name for '" + code + "'"));
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DeviatingResultIndicator.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DeviatingResultIndicator.java
@@ -18,8 +18,8 @@ public enum DeviatingResultIndicator {
 
     public static DeviatingResultIndicator fromCode(String code) {
         return Arrays.stream(DeviatingResultIndicator.values())
-            .filter(c -> c.code.equals(code))
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("No deviating result indicator for '" + code + "'"));
+                .filter(c -> c.code.equals(code))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No deviating result indicator for '" + code + "'"));
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DiagnosticReportCode.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DiagnosticReportCode.java
@@ -23,7 +23,7 @@ public class DiagnosticReportCode extends Segment {
     public static DiagnosticReportCode fromString(final String edifactString) {
         if (!edifactString.startsWith(KEY)) {
             throw new IllegalArgumentException("Can't create " + DiagnosticReportCode.class.getSimpleName()
-                + " from " + edifactString);
+                    + " from " + edifactString);
         }
         final String[] keySplit = Split.byPlus(edifactString);
         final String code = keySplit[1];

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DiagnosticReportDateIssued.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DiagnosticReportDateIssued.java
@@ -28,12 +28,12 @@ public class DiagnosticReportDateIssued extends Segment {
     private final LocalDateTime dateIssued;
 
     private static final DateTimeFormatter DATE_TIME_FORMATTER =
-        DateTimeFormatter.ofPattern("yyyMMddHHmm").withZone(TimestampService.UK_ZONE);
+            DateTimeFormatter.ofPattern("yyyMMddHHmm").withZone(TimestampService.UK_ZONE);
 
     public static DiagnosticReportDateIssued fromString(final String edifactString) {
         if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException("Can't create " + DiagnosticReportDateIssued.class.getSimpleName()
-                + " from " + edifactString);
+                    + " from " + edifactString);
         }
 
         final String[] keySplit = Split.byPlus(edifactString);
@@ -49,5 +49,6 @@ public class DiagnosticReportDateIssued extends Segment {
     }
 
     @Override
-    public void validate() throws EdifactValidationException { }
+    public void validate() throws EdifactValidationException {
+    }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DiagnosticReportStatus.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DiagnosticReportStatus.java
@@ -24,7 +24,7 @@ public class DiagnosticReportStatus extends Segment {
     public static DiagnosticReportStatus fromString(final String edifactString) {
         if (!edifactString.startsWith(KEY)) {
             throw new IllegalArgumentException("Can't create " + DiagnosticReportStatus.class.getSimpleName()
-                + " from " + edifactString);
+                    + " from " + edifactString);
         }
         final String detail = Split.byPlus(edifactString)[1];
         final String event = Split.byPlus(edifactString)[2];

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/FreeTextSegment.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/FreeTextSegment.java
@@ -29,7 +29,7 @@ public class FreeTextSegment extends Segment {
     public static FreeTextSegment fromString(final String edifact) {
         if (!edifact.startsWith(KEY)) {
             throw new IllegalArgumentException(
-                "Can't create " + FreeTextSegment.class.getSimpleName() + " from " + edifact);
+                    "Can't create " + FreeTextSegment.class.getSimpleName() + " from " + edifact);
         }
 
         final String[] split = Split.byPlus(edifact);
@@ -39,13 +39,13 @@ public class FreeTextSegment extends Segment {
         final String[] freeTexts = Split.byColon(freeTextComponent);
         if (freeTexts.length > MAXIMUM_FREE_TEXTS) {
             throw new IllegalArgumentException(
-                "Can't create " + FreeTextSegment.class.getSimpleName() + " from " + edifact
-                    + " because too many free texts");
+                    "Can't create " + FreeTextSegment.class.getSimpleName() + " from " + edifact
+                            + " because too many free texts");
         }
 
         final var texts = Arrays.stream(freeTexts)
-            .filter(line -> !StringUtils.isBlank(line))
-            .toArray(String[]::new);
+                .filter(line -> !StringUtils.isBlank(line))
+                .toArray(String[]::new);
         return new FreeTextSegment(FreeTextType.fromCode(typeCode), texts);
     }
 
@@ -58,12 +58,12 @@ public class FreeTextSegment extends Segment {
     public void validate() throws EdifactValidationException {
         if (texts.length == 0 || texts[0].isBlank()) {
             throw new EdifactValidationException(KEY + PLUS_SEPARATOR + type.getQualifier()
-                + ": At least one free text must be given.");
+                    + ": At least one free text must be given.");
         }
 
         if (texts.length > MAXIMUM_FREE_TEXTS) {
             throw new EdifactValidationException(KEY + PLUS_SEPARATOR + type.getQualifier()
-                + ": At most " + MAXIMUM_FREE_TEXTS + " free texts may be given.");
+                    + ": At most " + MAXIMUM_FREE_TEXTS + " free texts may be given.");
         }
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/FreeTextType.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/FreeTextType.java
@@ -18,8 +18,8 @@ public enum FreeTextType {
 
     public static FreeTextType fromCode(final String code) {
         return Arrays.stream(FreeTextType.values())
-            .filter(c -> c.qualifier.equals(code))
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("No free text type for '" + code + "'"));
+                .filter(c -> c.qualifier.equals(code))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No free text type for '" + code + "'"));
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/Gender.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/Gender.java
@@ -19,8 +19,8 @@ public enum Gender {
 
     public static Gender fromCode(final String code) {
         return Arrays.stream(Gender.values())
-            .filter(gender -> gender.code.equals(code))
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("No gender name for '" + code + "'"));
+                .filter(gender -> gender.code.equals(code))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No gender name for '" + code + "'"));
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/HealthcareRegistrationIdentificationCode.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/HealthcareRegistrationIdentificationCode.java
@@ -18,9 +18,10 @@ public enum HealthcareRegistrationIdentificationCode {
 
     public static HealthcareRegistrationIdentificationCode fromCode(@NonNull String code) {
         return Arrays.stream(HealthcareRegistrationIdentificationCode.values())
-            .filter(c -> code.equals(c.getCode()))
-            .findFirst()
-            .orElseThrow(
-                () -> new IllegalArgumentException("No HealthcareRegistrationIdentificationCode for '" + code + "'"));
+                .filter(c -> code.equals(c.getCode()))
+                .findFirst()
+                .orElseThrow(
+                        () -> new IllegalArgumentException(
+                                "No HealthcareRegistrationIdentificationCode for '" + code + "'"));
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/Interchange.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/Interchange.java
@@ -12,11 +12,11 @@ public class Interchange extends Section {
 
     @Getter(lazy = true)
     private final InterchangeHeader interchangeHeader =
-        InterchangeHeader.fromString(extractSegment(InterchangeHeader.KEY));
+            InterchangeHeader.fromString(extractSegment(InterchangeHeader.KEY));
 
     @Getter(lazy = true)
     private final InterchangeTrailer interchangeTrailer =
-        InterchangeTrailer.fromString(extractSegment(InterchangeTrailer.KEY));
+            InterchangeTrailer.fromString(extractSegment(InterchangeTrailer.KEY));
 
     @Getter
     @Setter
@@ -42,15 +42,15 @@ public class Interchange extends Section {
             getInterchangeTrailer().validate();
             if (!getInterchangeHeader().getSequenceNumber().equals(getInterchangeTrailer().getSequenceNumber())) {
                 throw new EdifactValidationException(
-                    "Interchange header sequence number does not match trailer sequence number");
+                        "Interchange header sequence number does not match trailer sequence number");
             }
         } catch (Exception ex) {
             throw new InterchangeParsingException(
-                "Error while parsing interchange",
-                getInterchangeHeader().getSender(),
-                getInterchangeHeader().getRecipient(),
-                getInterchangeHeader().getSequenceNumber(),
-                ex);
+                    "Error while parsing interchange",
+                    getInterchangeHeader().getSender(),
+                    getInterchangeHeader().getRecipient(),
+                    getInterchangeHeader().getSequenceNumber(),
+                    ex);
         }
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/InterchangeHeader.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/InterchangeHeader.java
@@ -22,7 +22,7 @@ public class InterchangeHeader extends Segment {
 
     protected static final String KEY = "UNB";
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyMMdd:HHmm")
-        .withZone(TimestampService.UK_ZONE);
+            .withZone(TimestampService.UK_ZONE);
     public static final long MAX_INTERCHANGE_SEQUENCE = 99_999_999L;
 
     private static final int SENDER_INDEX = 2;
@@ -38,19 +38,19 @@ public class InterchangeHeader extends Segment {
     public static InterchangeHeader fromString(final String edifactString) {
         if (!edifactString.startsWith(KEY)) {
             throw new IllegalArgumentException("Can't create " + InterchangeHeader.class.getSimpleName()
-                + " from " + edifactString);
+                    + " from " + edifactString);
         }
 
         final var split = Split.byPlus(edifactString);
 
         return InterchangeHeader.builder()
-            .sender(SENDER_INDEX < split.length ? split[SENDER_INDEX] : null)
-            .recipient(RECIPIENT_INDEX < split.length ? split[RECIPIENT_INDEX] : null)
-            .sequenceNumber(SEQUENCE_NUMBER_INDEX < split.length ? parseLong(split[SEQUENCE_NUMBER_INDEX]) : null)
-            .translationTime(TRANSLATION_TIME_INDEX < split.length
-                ? getTranslationTime(split[TRANSLATION_TIME_INDEX])
-                : null)
-            .build();
+                .sender(SENDER_INDEX < split.length ? split[SENDER_INDEX] : null)
+                .recipient(RECIPIENT_INDEX < split.length ? split[RECIPIENT_INDEX] : null)
+                .sequenceNumber(SEQUENCE_NUMBER_INDEX < split.length ? parseLong(split[SEQUENCE_NUMBER_INDEX]) : null)
+                .translationTime(TRANSLATION_TIME_INDEX < split.length
+                        ? getTranslationTime(split[TRANSLATION_TIME_INDEX])
+                        : null)
+                .build();
     }
 
     @Override
@@ -74,7 +74,7 @@ public class InterchangeHeader extends Segment {
         }
         if (getSequenceNumber() < 1 || getSequenceNumber() > MAX_INTERCHANGE_SEQUENCE) {
             throw new EdifactValidationException(
-                getKey() + ": Attribute sequenceNumber must be between 1 and " + MAX_INTERCHANGE_SEQUENCE);
+                    getKey() + ": Attribute sequenceNumber must be between 1 and " + MAX_INTERCHANGE_SEQUENCE);
         }
     }
 
@@ -95,8 +95,8 @@ public class InterchangeHeader extends Segment {
         }
         try {
             var translationTime = ZonedDateTime.parse(
-                translationTimeStr,
-                DateTimeFormatter.ofPattern("yyMMdd:HHmm").withZone(TimestampService.UK_ZONE));
+                    translationTimeStr,
+                    DateTimeFormatter.ofPattern("yyMMdd:HHmm").withZone(TimestampService.UK_ZONE));
             return translationTime.toInstant();
         } catch (Exception ex) {
             throw new EdifactValidationException(KEY + ": Error parsing time", ex);

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/InterchangeTrailer.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/InterchangeTrailer.java
@@ -41,17 +41,17 @@ public class InterchangeTrailer extends Segment {
     public static InterchangeTrailer fromString(String edifactString) {
         if (!edifactString.startsWith(KEY)) {
             throw new IllegalArgumentException("Can't create " + InterchangeTrailer.class.getSimpleName()
-                + " from " + edifactString);
+                    + " from " + edifactString);
         }
 
         final var split = Split.byPlus(edifactString);
 
         return InterchangeTrailer.builder()
-            .sequenceNumber(
-                split.length > SEQUENCE_NUMBER_INDEX ? parseLong(split[SEQUENCE_NUMBER_INDEX]) : null)
-            .numberOfMessages(
-                split.length > NUMBER_OF_MESSAGES_INDEX ? parseInt(split[NUMBER_OF_MESSAGES_INDEX]) : null)
-            .build();
+                .sequenceNumber(
+                        split.length > SEQUENCE_NUMBER_INDEX ? parseLong(split[SEQUENCE_NUMBER_INDEX]) : null)
+                .numberOfMessages(
+                        split.length > NUMBER_OF_MESSAGES_INDEX ? parseInt(split[NUMBER_OF_MESSAGES_INDEX]) : null)
+                .build();
     }
 
     private static Long parseLong(String longString) {

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/LaboratoryInvestigation.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/LaboratoryInvestigation.java
@@ -31,7 +31,7 @@ public class LaboratoryInvestigation extends Segment {
     public static LaboratoryInvestigation fromString(String edifactString) {
         if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException("Can't create " + LaboratoryInvestigation.class.getSimpleName()
-                + " from " + edifactString);
+                    + " from " + edifactString);
         }
 
         final String[] keySplit = Split.byPlus(edifactString);

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/LaboratoryInvestigationResult.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/LaboratoryInvestigationResult.java
@@ -44,15 +44,15 @@ public class LaboratoryInvestigationResult extends Segment {
         final String deviatingResultIndicator = extractDeviatingResultIndicator(keySplit);
 
         return LaboratoryInvestigationResult.builder()
-            .measurementValue(measurementValue)
-            .measurementValueComparator(StringUtils.isNotBlank(measurementValueComparator)
-                    ? MeasurementValueComparator.fromCode(measurementValueComparator)
-                    : null)
-            .measurementUnit(measurementUnit)
-            .deviatingResultIndicator(StringUtils.isNotBlank(deviatingResultIndicator)
-                    ? DeviatingResultIndicator.fromCode(deviatingResultIndicator)
-                    : null)
-            .build();
+                .measurementValue(measurementValue)
+                .measurementValueComparator(StringUtils.isNotBlank(measurementValueComparator)
+                        ? MeasurementValueComparator.fromCode(measurementValueComparator)
+                        : null)
+                .measurementUnit(measurementUnit)
+                .deviatingResultIndicator(StringUtils.isNotBlank(deviatingResultIndicator)
+                        ? DeviatingResultIndicator.fromCode(deviatingResultIndicator)
+                        : null)
+                .build();
     }
 
     private static BigDecimal extractMeasurementValue(String[] keySplit) {

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MeasurementValueComparator.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MeasurementValueComparator.java
@@ -18,8 +18,8 @@ public enum MeasurementValueComparator {
 
     public static MeasurementValueComparator fromCode(String code) {
         return Arrays.stream(MeasurementValueComparator.values())
-            .filter(c -> c.code.equals(code))
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("No measurement value comparator for '" + code + "'"));
+                .filter(c -> c.code.equals(code))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No measurement value comparator for '" + code + "'"));
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/Message.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/Message.java
@@ -14,27 +14,27 @@ public class Message extends Section {
 
     @Getter(lazy = true)
     private final MessageHeader messageHeader =
-        MessageHeader.fromString(extractSegment(MessageHeader.KEY));
+            MessageHeader.fromString(extractSegment(MessageHeader.KEY));
 
     @Getter(lazy = true)
     private final HealthAuthorityNameAndAddress healthAuthorityNameAndAddress =
-        HealthAuthorityNameAndAddress.fromString(extractSegment(HealthAuthorityNameAndAddress.KEY_QUALIFIER));
+            HealthAuthorityNameAndAddress.fromString(extractSegment(HealthAuthorityNameAndAddress.KEY_QUALIFIER));
 
     @Getter(lazy = true)
     private final List<InvolvedParty> involvedParties = InvolvedParty.createMultiple(getEdifactSegments().stream()
-        .dropWhile(segment -> !segment.startsWith(InvolvedParty.INDICATOR))
-        .takeWhile(segment -> !segment.startsWith(ServiceReportDetails.INDICATOR))
-        .collect(toList()));
+            .dropWhile(segment -> !segment.startsWith(InvolvedParty.INDICATOR))
+            .takeWhile(segment -> !segment.startsWith(ServiceReportDetails.INDICATOR))
+            .collect(toList()));
 
     @Getter(lazy = true)
     private final ServiceReportDetails serviceReportDetails = new ServiceReportDetails(getEdifactSegments().stream()
-        .dropWhile(segment -> !segment.startsWith(ServiceReportDetails.INDICATOR))
-        .takeWhile(segment -> !segment.startsWith(MessageTrailer.KEY))
-        .collect(toList()));
+            .dropWhile(segment -> !segment.startsWith(ServiceReportDetails.INDICATOR))
+            .takeWhile(segment -> !segment.startsWith(MessageTrailer.KEY))
+            .collect(toList()));
 
     @Getter(lazy = true)
     private final MessageTrailer messageTrailer =
-        MessageTrailer.fromString(extractSegment(MessageTrailer.KEY));
+            MessageTrailer.fromString(extractSegment(MessageTrailer.KEY));
 
     @Getter
     @Setter
@@ -46,17 +46,17 @@ public class Message extends Section {
 
     public String findFirstGpCode() {
         return extractOptionalSegment(GpNameAndAddress.KEY_QUALIFIER)
-            .stream()
-            .map(GpNameAndAddress::fromString)
-            .map(GpNameAndAddress::getIdentifier)
-            .findFirst()
-            .orElse(DEFAULT_GP_CODE);
+                .stream()
+                .map(GpNameAndAddress::fromString)
+                .map(GpNameAndAddress::getIdentifier)
+                .findFirst()
+                .orElse(DEFAULT_GP_CODE);
     }
 
     @Override
     public String toString() {
         return String.format("Message{SIS: %s, SMS: %s}",
-            getInterchange().getInterchangeHeader().getSequenceNumber(),
-            getMessageHeader().getSequenceNumber());
+                getInterchange().getInterchangeHeader().getSequenceNumber(),
+                getMessageHeader().getSequenceNumber());
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageHeader.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageHeader.java
@@ -35,14 +35,14 @@ public class MessageHeader extends Segment {
         }
         if (sequenceNumber < 1 || sequenceNumber > MAX_MESSAGE_SEQUENCE) {
             throw new EdifactValidationException(KEY + ": Attribute sequenceNumber must be between 1 and "
-                + MAX_MESSAGE_SEQUENCE);
+                    + MAX_MESSAGE_SEQUENCE);
         }
     }
 
     public static MessageHeader fromString(final String edifactString) {
         if (!edifactString.startsWith(KEY)) {
             throw new IllegalArgumentException("Can't create " + MessageHeader.class.getSimpleName()
-                + " from " + edifactString);
+                    + " from " + edifactString);
         }
         final String[] split = Split.byPlus(edifactString);
         return new MessageHeader(Long.valueOf(split[1]));

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageRecipientNameAndAddress.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageRecipientNameAndAddress.java
@@ -28,18 +28,18 @@ public class MessageRecipientNameAndAddress extends Segment {
     public static MessageRecipientNameAndAddress fromString(final String edifact) {
         if (!edifact.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException(
-                "Can't create " + MessageRecipientNameAndAddress.class.getSimpleName() + " from " + edifact);
+                    "Can't create " + MessageRecipientNameAndAddress.class.getSimpleName() + " from " + edifact);
         }
 
         String[] keySplit = Split.byPlus(edifact);
         String identifier = Split.byColon(keySplit[2])[0];
         String code = Split.byColon(keySplit[2])[1];
         String recipientName = keySplit.length > MESSAGE_RECIPIENT_NAME_INDEX
-            ? keySplit[MESSAGE_RECIPIENT_NAME_INDEX]
-            : null;
+                ? keySplit[MESSAGE_RECIPIENT_NAME_INDEX]
+                : null;
 
         return new MessageRecipientNameAndAddress(identifier, HealthcareRegistrationIdentificationCode.fromCode(code),
-            recipientName);
+                recipientName);
     }
 
     @Override

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageTrailer.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageTrailer.java
@@ -33,21 +33,21 @@ public class MessageTrailer extends Segment {
         }
         if (sequenceNumber <= 0) {
             throw new EdifactValidationException(KEY
-                + ": Attribute sequenceNumber must be greater than or equal to zero");
+                    + ": Attribute sequenceNumber must be greater than or equal to zero");
         }
         if (numberOfSegments <= 1) {
             throw new EdifactValidationException(KEY
-                + ": Attribute numberOfSegments must be greater than or equal to 2");
+                    + ": Attribute numberOfSegments must be greater than or equal to 2");
         }
     }
 
     public static MessageTrailer fromString(String edifactString) {
         if (!edifactString.startsWith(KEY)) {
             throw new IllegalArgumentException("Can't create " + MessageTrailer.class.getSimpleName()
-                + " from " + edifactString);
+                    + " from " + edifactString);
         }
         final String[] split = Split.byPlus(edifactString);
         return new MessageTrailer(Integer.parseInt(split[1]))
-            .setSequenceNumber(Long.parseLong(split[2]));
+                .setSequenceNumber(Long.parseLong(split[2]));
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PatientIdentificationType.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PatientIdentificationType.java
@@ -16,8 +16,9 @@ public enum PatientIdentificationType {
 
     public static PatientIdentificationType fromCode(final String code) {
         return Arrays.stream(PatientIdentificationType.values())
-            .filter(patientIdentificationType -> patientIdentificationType.getCode().equals(code))
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("No patientIdentificationType name for '" + code + "'"));
+                .filter(patientIdentificationType -> patientIdentificationType.getCode().equals(code))
+                .findFirst()
+                .orElseThrow(
+                        () -> new IllegalArgumentException("No patientIdentificationType name for '" + code + "'"));
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PerformerNameAndAddress.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PerformerNameAndAddress.java
@@ -1,10 +1,9 @@
 package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
 
-import org.apache.commons.lang3.StringUtils;
-
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.EdifactValidationException;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.Split;
 
@@ -32,7 +31,7 @@ public class PerformerNameAndAddress extends Segment {
     public static PerformerNameAndAddress fromString(String edifactString) {
         if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException(
-                "Can't create " + PerformerNameAndAddress.class.getSimpleName() + " from " + edifactString
+                    "Can't create " + PerformerNameAndAddress.class.getSimpleName() + " from " + edifactString
             );
         }
 
@@ -45,16 +44,16 @@ public class PerformerNameAndAddress extends Segment {
             // if identifier is blank - organisation/department
             String performingOrganisationName = keySplit[PERFORMING_NAME_INDEX_IN_EDIFACT_STRING];
             return PerformerNameAndAddress.builder()
-                .performingOrganisationName(performingOrganisationName)
-                .build();
+                    .performingOrganisationName(performingOrganisationName)
+                    .build();
         } else {
             String performerCode = colonSplit[1];
             String performerName = keySplit[PERFORMING_NAME_INDEX_IN_EDIFACT_STRING];
             return PerformerNameAndAddress.builder()
-                .identifier(performerID)
-                .code(HealthcareRegistrationIdentificationCode.fromCode(performerCode))
-                .performerName(performerName)
-                .build();
+                    .identifier(performerID)
+                    .code(HealthcareRegistrationIdentificationCode.fromCode(performerCode))
+                    .performerName(performerName)
+                    .build();
         }
     }
 

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonDateOfBirth.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonDateOfBirth.java
@@ -49,7 +49,7 @@ public class PersonDateOfBirth extends Segment {
     public static PersonDateOfBirth fromString(final String edifactString) {
         if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException("Can't create " + PersonDateOfBirth.class.getSimpleName()
-                + " from " + edifactString);
+                    + " from " + edifactString);
         }
         final String input = Split.byPlus(edifactString)[1];
         final String dateOfBirth = Split.byColon(input)[1];
@@ -61,8 +61,8 @@ public class PersonDateOfBirth extends Segment {
             final String formattedFhirDate = getFormattedFhirDate(dateOfBirth, format);
 
             dateOfBirthBuilder
-                .dateOfBirth(formattedFhirDate)
-                .dateFormat(DateFormat.fromCode(format));
+                    .dateOfBirth(formattedFhirDate)
+                    .dateFormat(DateFormat.fromCode(format));
         }
 
         return dateOfBirthBuilder.build();

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonName.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonName.java
@@ -43,14 +43,14 @@ public class PersonName extends Segment {
     public void validate() throws EdifactValidationException {
         if (isBlank(nhsNumber) && patientIdentificationType == null && isBlank(surname)) {
             throw new EdifactValidationException(KEY + ": At least one of patient identification and person "
-                + "name details are required");
+                    + "name details are required");
         }
     }
 
     public static PersonName fromString(final String edifactString) {
         if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException("Can't create " + PersonName.class.getSimpleName()
-                + " from " + edifactString);
+                    + " from " + edifactString);
         }
 
         final String nhsNumber = extractNhsNumber(edifactString);
@@ -59,17 +59,17 @@ public class PersonName extends Segment {
 
         if (isBlank(nhsNumber) && patientIdentificationType == null && isBlank(surname)) {
             throw new EdifactValidationException(KEY + ": At least one of patient identification and person name "
-                + "details are required");
+                    + "details are required");
         }
 
         return PersonName.builder()
-            .nhsNumber(nhsNumber)
-            .patientIdentificationType(patientIdentificationType)
-            .surname(surname)
-            .firstForename(extractNamePart(FIRST_NAME_QUALIFIER, edifactString))
-            .title(extractNamePart(TITLE_QUALIFIER, edifactString))
-            .secondForename(extractNamePart(MIDDLE_NAME_QUALIFIER, edifactString))
-            .build();
+                .nhsNumber(nhsNumber)
+                .patientIdentificationType(patientIdentificationType)
+                .surname(surname)
+                .firstForename(extractNamePart(FIRST_NAME_QUALIFIER, edifactString))
+                .title(extractNamePart(TITLE_QUALIFIER, edifactString))
+                .secondForename(extractNamePart(MIDDLE_NAME_QUALIFIER, edifactString))
+                .build();
     }
 
     private static String extractNhsNumber(final String edifactString) {
@@ -90,10 +90,10 @@ public class PersonName extends Segment {
 
     private static String extractNamePart(final String qualifier, final String text) {
         return Arrays.stream(Split.byPlus(text))
-            .filter(value -> value.startsWith(qualifier))
-            .map(value -> Split.byColon(value)[1])
-            .findFirst()
-            .orElse(null);
+                .filter(value -> value.startsWith(qualifier))
+                .map(value -> Split.byColon(value)[1])
+                .findFirst()
+                .orElse(null);
     }
 
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonSex.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonSex.java
@@ -31,7 +31,7 @@ public class PersonSex extends Segment {
     public static PersonSex fromString(final String edifactString) {
         if (!edifactString.startsWith(KEY)) {
             throw new IllegalArgumentException("Can't create " + PersonSex.class.getSimpleName()
-                + " from " + edifactString);
+                    + " from " + edifactString);
         }
         final String[] components = Split.byPlus(edifactString);
         final PersonSexBuilder builder = PersonSex.builder();

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RangeDetail.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RangeDetail.java
@@ -10,7 +10,7 @@ import java.math.BigDecimal;
 
 /**
  * Examples:
- *
+ * <p>
  * {@code RND+U+170+1100'}: between 170 and 1100<br/>
  * {@code RND+U++999'}: less than 999<br/>
  */
@@ -31,16 +31,16 @@ public class RangeDetail extends Segment {
     public static RangeDetail fromString(final String edifact) {
         if (!edifact.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException("Can't create " + RangeDetail.class.getSimpleName()
-                + " from " + edifact);
+                    + " from " + edifact);
         }
 
         final String[] split = Split.byPlus(edifact);
         final BigDecimal lowerLimit = split[INDEX_LOWER_LIMIT].isBlank()
-            ? null
-            : new BigDecimal(split[INDEX_LOWER_LIMIT]);
+                ? null
+                : new BigDecimal(split[INDEX_LOWER_LIMIT]);
         final BigDecimal upperLimit = split[INDEX_UPPER_LIMIT].isBlank()
-            ? null
-            : new BigDecimal(split[INDEX_UPPER_LIMIT]);
+                ? null
+                : new BigDecimal(split[INDEX_UPPER_LIMIT]);
 
         return new RangeDetail(lowerLimit, upperLimit);
     }
@@ -54,7 +54,7 @@ public class RangeDetail extends Segment {
     public void validate() throws EdifactValidationException {
         if (lowerLimit == null && upperLimit == null) {
             throw new EdifactValidationException(KEY
-                + ": At least one of lower reference limit and upper reference limit is required");
+                    + ": At least one of lower reference limit and upper reference limit is required");
         }
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/Reference.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/Reference.java
@@ -23,10 +23,10 @@ public class Reference extends Segment {
     public static Reference fromString(final String edifact) {
         if (!edifact.startsWith(KEY)) {
             throw new IllegalArgumentException(
-                "Can't create " + Reference.class.getSimpleName() + " from " + edifact);
+                    "Can't create " + Reference.class.getSimpleName() + " from " + edifact);
         }
         String[] data = Split.byColon(
-            Split.byPlus(edifact)[1]
+                Split.byPlus(edifact)[1]
         );
         return new Reference(ReferenceType.fromCode(data[0]), data[1]);
     }
@@ -40,7 +40,7 @@ public class Reference extends Segment {
     public void validate() throws EdifactValidationException {
         if (!number.matches("\\p{Alnum}{1,6}")) {
             throw new EdifactValidationException(
-                KEY + ": attribute number must be an alphanumeric string of up to 6 characters");
+                    KEY + ": attribute number must be an alphanumeric string of up to 6 characters");
         }
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ReferenceType.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ReferenceType.java
@@ -20,8 +20,8 @@ public enum ReferenceType {
 
     public static ReferenceType fromCode(final String code) {
         return Arrays.stream(ReferenceType.values())
-            .filter(referenceType -> referenceType.qualifier.equals(code))
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("No reference qualifier for '" + code + "'"));
+                .filter(referenceType -> referenceType.qualifier.equals(code))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No reference qualifier for '" + code + "'"));
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ReportStatusCode.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ReportStatusCode.java
@@ -1,10 +1,10 @@
 package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
 
-import java.util.Arrays;
-
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
@@ -16,9 +16,9 @@ public enum ReportStatusCode {
 
     public static ReportStatusCode fromCode(@NonNull String code) {
         return Arrays.stream(ReportStatusCode.values())
-            .filter(c -> code.equals(c.getCode()))
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("No Report Status Code for '" + code + "'"));
+                .filter(c -> code.equals(c.getCode()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No Report Status Code for '" + code + "'"));
     }
 
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RequesterNameAndAddress.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RequesterNameAndAddress.java
@@ -32,7 +32,7 @@ public class RequesterNameAndAddress extends Segment {
     public static RequesterNameAndAddress fromString(final String edifactString) {
         if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException("Can't create " + RequesterNameAndAddress.class.getSimpleName()
-                + " from " + edifactString);
+                    + " from " + edifactString);
         }
 
         final String[] keySplit = Split.byPlus(edifactString);
@@ -41,9 +41,9 @@ public class RequesterNameAndAddress extends Segment {
         final String requesterName = keySplit[REQUESTER_NAME_INDEX_IN_EDIFACT_STRING];
 
         return new RequesterNameAndAddress(
-            identifier,
-            HealthcareRegistrationIdentificationCode.fromCode(code),
-            requesterName
+                identifier,
+                HealthcareRegistrationIdentificationCode.fromCode(code),
+                requesterName
         );
     }
 
@@ -60,7 +60,7 @@ public class RequesterNameAndAddress extends Segment {
 
         if (healthcareRegistrationIdentificationCode.getCode().isBlank()) {
             throw new EdifactValidationException(
-                KEY + ": Attribute code in healthcareRegistrationIdentificationCode is required");
+                    KEY + ": Attribute code in healthcareRegistrationIdentificationCode is required");
         }
 
         if (requesterName.isBlank()) {

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/Section.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/Section.java
@@ -17,19 +17,19 @@ public abstract class Section {
 
     protected List<String> extractSegments(final String key) {
         return edifactSegments.stream()
-            .map(String::strip)
-            .filter(segment -> segment.startsWith(key))
-            .collect(Collectors.toList());
+                .map(String::strip)
+                .filter(segment -> segment.startsWith(key))
+                .collect(Collectors.toList());
     }
 
     protected Optional<String> extractOptionalSegment(final String key) {
         return extractSegments(key).stream()
-            .findFirst();
+                .findFirst();
     }
 
     protected String extractSegment(final String key) {
         return extractOptionalSegment(key)
-            .orElseThrow(() -> new MissingSegmentException("EDIFACT section is missing segment " + key));
+                .orElseThrow(() -> new MissingSegmentException("EDIFACT section is missing segment " + key));
     }
 
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SequenceDetails.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SequenceDetails.java
@@ -20,7 +20,7 @@ public class SequenceDetails extends Segment {
     public static SequenceDetails fromString(final String edifact) {
         if (!edifact.startsWith(KEY)) {
             throw new IllegalArgumentException(
-                "Can't create " + SequenceDetails.class.getSimpleName() + " from " + edifact);
+                    "Can't create " + SequenceDetails.class.getSimpleName() + " from " + edifact);
         }
         final String sequenceValue = Split.byPlus(edifact)[2];
         return new SequenceDetails(sequenceValue);
@@ -35,7 +35,7 @@ public class SequenceDetails extends Segment {
     public void validate() throws EdifactValidationException {
         if (!number.matches("\\p{Alnum}{1,6}")) {
             throw new EdifactValidationException(
-                KEY + ": attribute number must be an alphanumeric string of up to 6 characters");
+                    KEY + ": attribute number must be an alphanumeric string of up to 6 characters");
         }
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ServiceProvider.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ServiceProvider.java
@@ -25,7 +25,7 @@ public class ServiceProvider extends Segment {
     public static ServiceProvider fromString(final String edifactString) {
         if (!edifactString.startsWith(KEY)) {
             throw new IllegalArgumentException("Can't create " + ServiceProvider.class.getSimpleName()
-                + " from " + edifactString);
+                    + " from " + edifactString);
         }
 
         final String[] keySplit = Split.byPlus(edifactString);

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ServiceProviderCode.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ServiceProviderCode.java
@@ -18,8 +18,8 @@ public enum ServiceProviderCode {
 
     public static ServiceProviderCode fromCode(@NonNull String code) {
         return Arrays.stream(ServiceProviderCode.values())
-            .filter(c -> code.equals(c.getCode()))
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("No service provider code for '" + code + "'"));
+                .filter(c -> code.equals(c.getCode()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No service provider code for '" + code + "'"));
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SpecimenCharacteristicType.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SpecimenCharacteristicType.java
@@ -24,7 +24,7 @@ public class SpecimenCharacteristicType extends Segment {
     public static SpecimenCharacteristicType fromString(String edifactString) {
         if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException(
-                "Can't create " + SpecimenCharacteristicType.class.getSimpleName() + " from " + edifactString);
+                    "Can't create " + SpecimenCharacteristicType.class.getSimpleName() + " from " + edifactString);
         }
         final String[] split = Split.byColon(edifactString);
         return new SpecimenCharacteristicType(split[TYPE_OF_SPECIMEN_DETAILS_INDEX]);

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SpecimenCollectionDateTime.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SpecimenCollectionDateTime.java
@@ -33,7 +33,7 @@ public class SpecimenCollectionDateTime extends Segment {
     public static SpecimenCollectionDateTime fromString(final String edifactString) {
         if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException(
-                "Can't create " + SpecimenCollectionDateTime.class.getSimpleName() + " from " + edifactString);
+                    "Can't create " + SpecimenCollectionDateTime.class.getSimpleName() + " from " + edifactString);
         }
         final String input = Split.byPlus(edifactString)[1];
         final String collectionDateTime = Split.byColon(input)[1];
@@ -41,12 +41,12 @@ public class SpecimenCollectionDateTime extends Segment {
 
         if (isBlank(collectionDateTime) || isBlank(format)) {
             throw new IllegalArgumentException("Can't create " + SpecimenCollectionDateTime.class.getSimpleName()
-                + " from " + edifactString + " because of missing date-time and/or format definition");
+                    + " from " + edifactString + " because of missing date-time and/or format definition");
         }
         return SpecimenCollectionDateTime.builder()
-            .collectionDateTime(collectionDateTime)
-            .dateFormat(DateFormat.fromCode(format))
-            .build();
+                .collectionDateTime(collectionDateTime)
+                .dateFormat(DateFormat.fromCode(format))
+                .build();
     }
 
     @Override

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SpecimenCollectionReceiptDateTime.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SpecimenCollectionReceiptDateTime.java
@@ -31,7 +31,8 @@ public class SpecimenCollectionReceiptDateTime extends Segment {
     public static SpecimenCollectionReceiptDateTime fromString(final String edifactString) {
         if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException(
-                "Can't create " + SpecimenCollectionReceiptDateTime.class.getSimpleName() + " from " + edifactString);
+                    "Can't create " + SpecimenCollectionReceiptDateTime.class.getSimpleName() + " from "
+                            + edifactString);
         }
         final String input = Split.byPlus(edifactString)[1];
         final String collectionReceiptDateTime = Split.byColon(input)[1];
@@ -39,13 +40,13 @@ public class SpecimenCollectionReceiptDateTime extends Segment {
 
         if (isBlank(collectionReceiptDateTime) || isBlank(format)) {
             throw new IllegalArgumentException("Can't create " + SpecimenCollectionReceiptDateTime.class.getSimpleName()
-                + " from " + edifactString + " because of missing date-time and/or format definition");
+                    + " from " + edifactString + " because of missing date-time and/or format definition");
         }
 
         return SpecimenCollectionReceiptDateTime.builder()
-            .collectionReceiptDateTime(collectionReceiptDateTime)
-            .dateFormat(DateFormat.fromCode(format))
-            .build();
+                .collectionReceiptDateTime(collectionReceiptDateTime)
+                .dateFormat(DateFormat.fromCode(format))
+                .build();
     }
 
     @Override

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SpecimenQuantity.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SpecimenQuantity.java
@@ -25,7 +25,7 @@ public class SpecimenQuantity extends Segment {
     public static SpecimenQuantity fromString(String edifactString) {
         if (!edifactString.startsWith(KEY_QUALIFIER)) {
             throw new IllegalArgumentException(
-                "Can't create " + SpecimenQuantity.class.getSimpleName() + " from " + edifactString);
+                    "Can't create " + SpecimenQuantity.class.getSimpleName() + " from " + edifactString);
         }
         final String[] splitByColon = Split.byColon(edifactString);
         final int quantity = Integer.parseInt(Split.byPlus(splitByColon[1])[0]);

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/TestStatus.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/TestStatus.java
@@ -24,7 +24,7 @@ public class TestStatus extends Segment {
     public static TestStatus fromString(String edifactString) {
         if (!edifactString.startsWith(KEY)) {
             throw new IllegalArgumentException("Can't create " + TestStatus.class.getSimpleName()
-                + " from " + edifactString);
+                    + " from " + edifactString);
         }
 
         final String[] keySplit = Split.byPlus(edifactString);

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/TestStatusCode.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/TestStatusCode.java
@@ -23,8 +23,8 @@ public enum TestStatusCode {
 
     public static TestStatusCode fromCode(@NonNull String code) {
         return Arrays.stream(TestStatusCode.values())
-            .filter(c -> code.equals(c.getCode()))
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("No test status code for '" + code + "'"));
+                .filter(c -> code.equals(c.getCode()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No test status code for '" + code + "'"));
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/UnstructuredAddress.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/UnstructuredAddress.java
@@ -29,7 +29,7 @@ public class UnstructuredAddress extends Segment {
     public static UnstructuredAddress fromString(final String edifact) {
         if (!edifact.startsWith(KEY)) {
             throw new IllegalArgumentException("Can't create " + UnstructuredAddress.class.getSimpleName()
-                + " from " + edifact);
+                    + " from " + edifact);
         }
         final String[] splitByPlus = Split.byPlus(edifact);
         final String[] splitByColon = Split.byColon(splitByPlus[INDEX_ADDRESS]);
@@ -54,8 +54,8 @@ public class UnstructuredAddress extends Segment {
     private String getAddressValue() {
         if (FORMAT.equals(format)) {
             return format
-                + COLON_SEPARATOR
-                + String.join(COLON_SEPARATOR, addressLines);
+                    + COLON_SEPARATOR
+                    + String.join(COLON_SEPARATOR, addressLines);
         }
         return "";
     }
@@ -66,7 +66,7 @@ public class UnstructuredAddress extends Segment {
         if (StringUtils.isBlank(postCode)) {
             if (addressLines == null || addressLines.length <= 1) {
                 throw new EdifactValidationException(KEY
-                    + ": attribute addressLines is required when postcode is missing");
+                        + ": attribute addressLines is required when postcode is missing");
             }
         }
 
@@ -74,7 +74,7 @@ public class UnstructuredAddress extends Segment {
         if (addressLines != null && addressLines.length > 0) {
             if (!FORMAT.equals(format)) {
                 throw new EdifactValidationException(KEY + ": format of '" + FORMAT
-                    + "' is required when postCode is missing");
+                        + "' is required when postCode is missing");
             }
             if (StringUtils.isBlank(addressLines[0])) {
                 throw new EdifactValidationException(KEY + ": attribute addressLines[0] is required");

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/message/Split.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/message/Split.java
@@ -9,7 +9,8 @@ public final class Split {
     private static final char FIELD_TERMINATOR = '+';
     private static final char SUB_FIELD_TERMINATOR = ':';
 
-    private Split() { }
+    private Split() {
+    }
 
     public static String[] bySegmentTerminator(String input) {
         return splitString(input, SEGMENT_TERMINATOR);

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/InvestigationSubject.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/InvestigationSubject.java
@@ -35,41 +35,41 @@ public class InvestigationSubject extends SegmentGroup {
 
     @Getter(lazy = true)
     private final Optional<Reference> referenceServiceSubject =
-        extractOptionalSegment(Reference.KEY + PLUS_SEPARATOR + ReferenceType.SERVICE_SUBJECT.getQualifier())
-            .map(Reference::fromString);
+            extractOptionalSegment(Reference.KEY + PLUS_SEPARATOR + ReferenceType.SERVICE_SUBJECT.getQualifier())
+                    .map(Reference::fromString);
 
     @Getter(lazy = true)
     private final Optional<UnstructuredAddress> address =
-        extractOptionalSegment(UnstructuredAddress.KEY)
-            .map(UnstructuredAddress::fromString);
+            extractOptionalSegment(UnstructuredAddress.KEY)
+                    .map(UnstructuredAddress::fromString);
 
     @Getter(lazy = true)
     private final PatientDetails details = new PatientDetails(getEdifactSegments().stream()
-        .dropWhile(segment -> !segment.startsWith(PatientDetails.INDICATOR))
-        .takeWhile(segment -> !segment.startsWith(SpecimenDetails.INDICATOR))
-        .takeWhile(segment -> !segment.startsWith(MessageTrailer.KEY))
-        .collect(toList()));
+            .dropWhile(segment -> !segment.startsWith(PatientDetails.INDICATOR))
+            .takeWhile(segment -> !segment.startsWith(SpecimenDetails.INDICATOR))
+            .takeWhile(segment -> !segment.startsWith(MessageTrailer.KEY))
+            .collect(toList()));
 
     @Getter(lazy = true)
     private final Optional<PatientClinicalInfo> clinicalInfo = PatientClinicalInfo.createOptional(
-        getEdifactSegments().stream()
-            .dropWhile(segment -> !segment.startsWith(PatientClinicalInfo.INDICATOR))
-            .takeWhile(segment -> !segment.startsWith(SpecimenDetails.INDICATOR))
-            .collect(toList()));
+            getEdifactSegments().stream()
+                    .dropWhile(segment -> !segment.startsWith(PatientClinicalInfo.INDICATOR))
+                    .takeWhile(segment -> !segment.startsWith(SpecimenDetails.INDICATOR))
+                    .collect(toList()));
 
     @Getter(lazy = true)
     private final List<SpecimenDetails> specimens = SpecimenDetails.createMultiple(getEdifactSegments().stream()
-        .dropWhile(segment -> !segment.startsWith(SpecimenDetails.INDICATOR))
-        .takeWhile(segment -> !segment.startsWith(LabResult.INDICATOR))
-        .takeWhile(segment -> !segment.startsWith(MessageTrailer.KEY))
-        .collect(toList()));
+            .dropWhile(segment -> !segment.startsWith(SpecimenDetails.INDICATOR))
+            .takeWhile(segment -> !segment.startsWith(LabResult.INDICATOR))
+            .takeWhile(segment -> !segment.startsWith(MessageTrailer.KEY))
+            .collect(toList()));
 
     @Getter(lazy = true)
     private final List<LabResult> labResults =
-        LabResult.createMultiple(getEdifactSegments().stream()
-            .dropWhile(segment -> !segment.startsWith(LabResult.INDICATOR))
-            .takeWhile(segment -> !segment.startsWith(MessageTrailer.KEY))
-            .collect(toList()));
+            LabResult.createMultiple(getEdifactSegments().stream()
+                    .dropWhile(segment -> !segment.startsWith(LabResult.INDICATOR))
+                    .takeWhile(segment -> !segment.startsWith(MessageTrailer.KEY))
+                    .collect(toList()));
 
     public InvestigationSubject(final List<String> edifactSegments) {
         super(edifactSegments);

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/InvolvedParty.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/InvolvedParty.java
@@ -36,31 +36,31 @@ public class InvolvedParty extends SegmentGroup {
 
     @Getter(lazy = true)
     private final Optional<PerformerNameAndAddress> performerNameAndAddress =
-        extractOptionalSegment(PerformerNameAndAddress.KEY_QUALIFIER)
-            .map(PerformerNameAndAddress::fromString);
+            extractOptionalSegment(PerformerNameAndAddress.KEY_QUALIFIER)
+                    .map(PerformerNameAndAddress::fromString);
 
     @Getter(lazy = true)
     private final Optional<RequesterNameAndAddress> requesterNameAndAddress =
-        extractOptionalSegment(RequesterNameAndAddress.KEY_QUALIFIER)
-            .map(RequesterNameAndAddress::fromString);
+            extractOptionalSegment(RequesterNameAndAddress.KEY_QUALIFIER)
+                    .map(RequesterNameAndAddress::fromString);
 
     @Getter(lazy = true)
     private final Optional<MessageRecipientNameAndAddress> recipientNameAndAddress =
-        extractOptionalSegment(MessageRecipientNameAndAddress.KEY_QUALIFIER)
-            .map(MessageRecipientNameAndAddress::fromString);
+            extractOptionalSegment(MessageRecipientNameAndAddress.KEY_QUALIFIER)
+                    .map(MessageRecipientNameAndAddress::fromString);
 
     @Getter(lazy = true)
     private final Optional<Reference> partnerAgreedId =
-        extractOptionalSegment(Reference.KEY + PLUS_SEPARATOR + ReferenceType.PARTNER_AGREED_ID.getQualifier())
-            .map(Reference::fromString);
+            extractOptionalSegment(Reference.KEY + PLUS_SEPARATOR + ReferenceType.PARTNER_AGREED_ID.getQualifier())
+                    .map(Reference::fromString);
 
     @Getter(lazy = true)
     private final ServiceProvider serviceProvider = ServiceProvider.fromString(extractSegment(ServiceProvider.KEY));
 
     public static List<InvolvedParty> createMultiple(@NonNull final List<String> edifactSegments) {
         return splitMultipleSegmentGroups(edifactSegments, INDICATOR).stream()
-            .map(InvolvedParty::new)
-            .collect(toList());
+                .map(InvolvedParty::new)
+                .collect(toList());
     }
 
     public InvolvedParty(final List<String> edifactSegments) {

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/LabResult.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/LabResult.java
@@ -45,50 +45,50 @@ public class LabResult extends SegmentGroup {
 
     @Getter(lazy = true)
     private final DiagnosticReportCode reportCode =
-        DiagnosticReportCode.fromString(extractSegment(DiagnosticReportCode.KEY));
+            DiagnosticReportCode.fromString(extractSegment(DiagnosticReportCode.KEY));
 
     @Getter(lazy = true)
     private final LaboratoryInvestigation investigation =
-        LaboratoryInvestigation.fromString(extractSegment(LaboratoryInvestigation.KEY_QUALIFIER));
+            LaboratoryInvestigation.fromString(extractSegment(LaboratoryInvestigation.KEY_QUALIFIER));
 
     @Getter(lazy = true)
     private final Optional<SequenceDetails> sequenceDetails =
-        extractOptionalSegment(SequenceDetails.KEY)
-            .map(SequenceDetails::fromString);
+            extractOptionalSegment(SequenceDetails.KEY)
+                    .map(SequenceDetails::fromString);
 
     @Getter(lazy = true)
     private final Optional<LaboratoryInvestigationResult> investigationResult =
-        extractOptionalSegment(LaboratoryInvestigationResult.KEY_QUALIFIER)
-            .map(LaboratoryInvestigationResult::fromString);
+            extractOptionalSegment(LaboratoryInvestigationResult.KEY_QUALIFIER)
+                    .map(LaboratoryInvestigationResult::fromString);
 
     @Getter(lazy = true)
     private final Optional<TestStatus> testStatus =
-        extractOptionalSegment(TestStatus.KEY)
-            .map(TestStatus::fromString);
+            extractOptionalSegment(TestStatus.KEY)
+                    .map(TestStatus::fromString);
 
     @Getter(lazy = true)
     private final List<FreeTextSegment> freeTexts =
-        extractSegments(FreeTextSegment.KEY).stream()
-            .map(FreeTextSegment::fromString)
-            .filter(segment -> List.of(FreeTextType.SERVICE_PROVIDER_COMMENT, FreeTextType.INVESTIGATION_RESULT,
-                FreeTextType.COMPLEX_REFERENCE_RANGE).contains(segment.getType()))
-            .collect(toList());
+            extractSegments(FreeTextSegment.KEY).stream()
+                    .map(FreeTextSegment::fromString)
+                    .filter(segment -> List.of(FreeTextType.SERVICE_PROVIDER_COMMENT, FreeTextType.INVESTIGATION_RESULT,
+                            FreeTextType.COMPLEX_REFERENCE_RANGE).contains(segment.getType()))
+                    .collect(toList());
 
     @Getter(lazy = true)
     private final Reference sequenceReference = Reference.fromString(
-        extractSegment(Reference.KEY));
+            extractSegment(Reference.KEY));
 
     @Getter(lazy = true)
     private final List<ResultReferenceRange> resultReferenceRanges =
-        ResultReferenceRange.createMultiple(getEdifactSegments().stream()
-            .dropWhile(segment -> !segment.startsWith(ResultReferenceRange.INDICATOR))
-            .takeWhile(segment -> !segment.startsWith(MessageTrailer.KEY))
-            .collect(toList()));
+            ResultReferenceRange.createMultiple(getEdifactSegments().stream()
+                    .dropWhile(segment -> !segment.startsWith(ResultReferenceRange.INDICATOR))
+                    .takeWhile(segment -> !segment.startsWith(MessageTrailer.KEY))
+                    .collect(toList()));
 
     public static List<LabResult> createMultiple(@NonNull final List<String> edifactSegments) {
         return splitMultipleSegmentGroups(edifactSegments, INDICATOR).stream()
-            .map(LabResult::new)
-            .collect(toList());
+                .map(LabResult::new)
+                .collect(toList());
     }
 
     public LabResult(final List<String> edifactSegments) {

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/PatientClinicalInfo.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/PatientClinicalInfo.java
@@ -31,14 +31,14 @@ public class PatientClinicalInfo extends SegmentGroup {
 
     @Getter(lazy = true)
     private final ClinicalInformationCode code =
-        ClinicalInformationCode.fromString(extractSegment(ClinicalInformationCode.KEY));
+            ClinicalInformationCode.fromString(extractSegment(ClinicalInformationCode.KEY));
 
     @Getter(lazy = true)
     private final List<FreeTextSegment> freeTexts =
-        extractSegments(FreeTextSegment.KEY).stream()
-            .map(FreeTextSegment::fromString)
-            .filter(segment -> FreeTextType.CLINICAL_INFO.equals(segment.getType()))
-            .collect(toList());
+            extractSegments(FreeTextSegment.KEY).stream()
+                    .map(FreeTextSegment::fromString)
+                    .filter(segment -> FreeTextType.CLINICAL_INFO.equals(segment.getType()))
+                    .collect(toList());
 
     public static Optional<PatientClinicalInfo> createOptional(@NonNull final List<String> edifactSegments) {
         if (edifactSegments.isEmpty() || !edifactSegments.get(0).startsWith(INDICATOR)) {

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/PatientDetails.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/PatientDetails.java
@@ -31,13 +31,13 @@ public class PatientDetails extends SegmentGroup {
 
     @Getter(lazy = true)
     private final Optional<PersonDateOfBirth> dateOfBirth =
-        extractOptionalSegment(PersonDateOfBirth.KEY_QUALIFIER)
-            .map(PersonDateOfBirth::fromString);
+            extractOptionalSegment(PersonDateOfBirth.KEY_QUALIFIER)
+                    .map(PersonDateOfBirth::fromString);
 
     @Getter(lazy = true)
     private final Optional<PersonSex> sex =
-        extractOptionalSegment(PersonSex.KEY)
-            .map(PersonSex::fromString);
+            extractOptionalSegment(PersonSex.KEY)
+                    .map(PersonSex::fromString);
 
     public PatientDetails(final List<String> edifactSegments) {
         super(edifactSegments);

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/ResultReferenceRange.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/ResultReferenceRange.java
@@ -35,14 +35,14 @@ public class ResultReferenceRange extends SegmentGroup {
 
     @Getter(lazy = true)
     private final Optional<FreeTextSegment> freeTexts =
-        extractOptionalSegment(FreeTextSegment.KEY + PLUS_SEPARATOR
-            + FreeTextType.REFERENCE_POPULATION_DEFINITION.getQualifier())
-            .map(FreeTextSegment::fromString);
+            extractOptionalSegment(FreeTextSegment.KEY + PLUS_SEPARATOR
+                    + FreeTextType.REFERENCE_POPULATION_DEFINITION.getQualifier())
+                    .map(FreeTextSegment::fromString);
 
     public static List<ResultReferenceRange> createMultiple(@NonNull final List<String> edifactSegments) {
         return splitMultipleSegmentGroups(edifactSegments, INDICATOR).stream()
-            .map(ResultReferenceRange::new)
-            .collect(toList());
+                .map(ResultReferenceRange::new)
+                .collect(toList());
     }
 
     public ResultReferenceRange(final List<String> edifactSegments) {

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/ServiceReportDetails.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/ServiceReportDetails.java
@@ -34,26 +34,26 @@ public class ServiceReportDetails extends SegmentGroup {
 
     @Getter(lazy = true)
     private final DiagnosticReportCode code =
-        DiagnosticReportCode.fromString(extractSegment(DiagnosticReportCode.KEY));
+            DiagnosticReportCode.fromString(extractSegment(DiagnosticReportCode.KEY));
 
     @Getter(lazy = true)
     private final Reference reference =
-        Reference.fromString(extractSegment(Reference.KEY + PLUS_SEPARATOR
-            + ReferenceType.DIAGNOSTIC_REPORT.getQualifier()));
+            Reference.fromString(extractSegment(Reference.KEY + PLUS_SEPARATOR
+                    + ReferenceType.DIAGNOSTIC_REPORT.getQualifier()));
 
     @Getter(lazy = true)
     private final DiagnosticReportStatus status =
-        DiagnosticReportStatus.fromString(extractSegment(DiagnosticReportStatus.KEY));
+            DiagnosticReportStatus.fromString(extractSegment(DiagnosticReportStatus.KEY));
 
     @Getter(lazy = true)
     private final DiagnosticReportDateIssued dateIssued =
-        DiagnosticReportDateIssued.fromString(extractSegment(DiagnosticReportDateIssued.KEY_QUALIFIER));
+            DiagnosticReportDateIssued.fromString(extractSegment(DiagnosticReportDateIssued.KEY_QUALIFIER));
 
     @Getter(lazy = true)
     private final InvestigationSubject subject = new InvestigationSubject(getEdifactSegments().stream()
-        .dropWhile(segment -> !segment.startsWith(InvestigationSubject.INDICATOR))
-        .takeWhile(segment -> !segment.startsWith(MessageTrailer.KEY))
-        .collect(toList()));
+            .dropWhile(segment -> !segment.startsWith(InvestigationSubject.INDICATOR))
+            .takeWhile(segment -> !segment.startsWith(MessageTrailer.KEY))
+            .collect(toList()));
 
     public ServiceReportDetails(final List<String> edifactSegments) {
         super(edifactSegments);

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/SpecimenDetails.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/SpecimenDetails.java
@@ -44,49 +44,49 @@ public class SpecimenDetails extends SegmentGroup {
 
     @Getter(lazy = true)
     private final Optional<SequenceDetails> sequenceDetails =
-        extractOptionalSegment(SequenceDetails.KEY)
-            .map(SequenceDetails::fromString);
+            extractOptionalSegment(SequenceDetails.KEY)
+                    .map(SequenceDetails::fromString);
 
     @Getter(lazy = true)
     private final SpecimenCharacteristicType characteristicType =
-        SpecimenCharacteristicType.fromString(extractSegment(SpecimenCharacteristicType.KEY_QUALIFIER));
+            SpecimenCharacteristicType.fromString(extractSegment(SpecimenCharacteristicType.KEY_QUALIFIER));
 
     @Getter(lazy = true)
     private final Optional<Reference> serviceRequesterReference =
-        extractOptionalSegment(Reference.KEY + PLUS_SEPARATOR + ReferenceType.SPECIMEN_BY_REQUESTER.getQualifier())
-            .map(Reference::fromString);
+            extractOptionalSegment(Reference.KEY + PLUS_SEPARATOR + ReferenceType.SPECIMEN_BY_REQUESTER.getQualifier())
+                    .map(Reference::fromString);
 
     @Getter(lazy = true)
     private final Optional<Reference> serviceProviderReference =
-        extractOptionalSegment(Reference.KEY + PLUS_SEPARATOR + ReferenceType.SPECIMEN_BY_PROVIDER.getQualifier())
-            .map(Reference::fromString);
+            extractOptionalSegment(Reference.KEY + PLUS_SEPARATOR + ReferenceType.SPECIMEN_BY_PROVIDER.getQualifier())
+                    .map(Reference::fromString);
 
     @Getter(lazy = true)
     private final Optional<SpecimenQuantity> quantity =
-        extractOptionalSegment(SpecimenQuantity.KEY_QUALIFIER)
-            .map(SpecimenQuantity::fromString);
+            extractOptionalSegment(SpecimenQuantity.KEY_QUALIFIER)
+                    .map(SpecimenQuantity::fromString);
 
     @Getter(lazy = true)
     private final Optional<SpecimenCollectionDateTime> collectionDateTime =
-        extractOptionalSegment(SpecimenCollectionDateTime.KEY_QUALIFIER)
-            .map(SpecimenCollectionDateTime::fromString);
+            extractOptionalSegment(SpecimenCollectionDateTime.KEY_QUALIFIER)
+                    .map(SpecimenCollectionDateTime::fromString);
 
     @Getter(lazy = true)
     private final Optional<SpecimenCollectionReceiptDateTime> collectionReceiptDateTime =
-        extractOptionalSegment(SpecimenCollectionReceiptDateTime.KEY_QUALIFIER)
-            .map(SpecimenCollectionReceiptDateTime::fromString);
+            extractOptionalSegment(SpecimenCollectionReceiptDateTime.KEY_QUALIFIER)
+                    .map(SpecimenCollectionReceiptDateTime::fromString);
 
     @Getter(lazy = true)
     private final List<FreeTextSegment> freeTexts =
-        extractSegments(FreeTextSegment.KEY + PLUS_SEPARATOR + FreeTextType.SERVICE_PROVIDER_COMMENT.getQualifier())
-            .stream()
-            .map(FreeTextSegment::fromString)
-            .collect(Collectors.toList());
+            extractSegments(FreeTextSegment.KEY + PLUS_SEPARATOR + FreeTextType.SERVICE_PROVIDER_COMMENT.getQualifier())
+                    .stream()
+                    .map(FreeTextSegment::fromString)
+                    .collect(Collectors.toList());
 
     public static List<SpecimenDetails> createMultiple(@NonNull final List<String> edifactSegments) {
         return splitMultipleSegmentGroups(edifactSegments, INDICATOR).stream()
-            .map(SpecimenDetails::new)
-            .collect(Collectors.toList());
+                .map(SpecimenDetails::new)
+                .collect(Collectors.toList());
     }
 
     public SpecimenDetails(final List<String> edifactSegments) {

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/outbound/OutboundMeshMessageBuilder.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/outbound/OutboundMeshMessageBuilder.java
@@ -29,25 +29,25 @@ public class OutboundMeshMessageBuilder {
             List<MessageProcessingResult> messageProcessingResults) {
         //TODO NIAD-1063: one of IAF, IAP, IRA
         return new MeshMessage()
-            .setWorkflowId(getOutboundWorkflowId(workflowId))
-            .setRecipient(interchange.getInterchangeHeader().getSender())
-            .setContent("TODO NIAD-1063");
+                .setWorkflowId(getOutboundWorkflowId(workflowId))
+                .setRecipient(interchange.getInterchangeHeader().getSender())
+                .setContent("TODO NIAD-1063");
     }
 
     public OutboundMeshMessage buildNhsAck(WorkflowId workflowId, InterchangeParsingException exception) {
         //TODO NIAD-1063: IAI
         return new MeshMessage()
-            .setWorkflowId(getOutboundWorkflowId(workflowId))
-            .setRecipient(exception.getSender())
-            .setContent("TODO NIAD-1063");
+                .setWorkflowId(getOutboundWorkflowId(workflowId))
+                .setRecipient(exception.getSender())
+                .setContent("TODO NIAD-1063");
     }
 
     public OutboundMeshMessage buildNhsAck(WorkflowId workflowId, MessagesParsingException exception) {
         //TODO NIAD-1063: IRM
         return new MeshMessage()
-            .setWorkflowId(getOutboundWorkflowId(workflowId))
-            .setRecipient(exception.getSender())
-            .setContent("TODO NIAD-1063");
+                .setWorkflowId(getOutboundWorkflowId(workflowId))
+                .setRecipient(exception.getSender())
+                .setContent("TODO NIAD-1063");
     }
 
     private WorkflowId getOutboundWorkflowId(WorkflowId workflowId) {

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/outbound/queue/MeshOutboundQueueService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/outbound/queue/MeshOutboundQueueService.java
@@ -37,9 +37,9 @@ public class MeshOutboundQueueService {
     private String meshOutboundQueueName;
 
     public void publish(final OutboundMeshMessage message) {
-        LOGGER.info(
-            "Publishing message to MESH outbound queue for asynchronous sending to MESH API recipient={} workflow={}",
-            message.getRecipient(), message.getWorkflowId());
+        LOGGER.info("Publishing message to MESH outbound queue for asynchronous sending to MESH API "
+                        + "recipient={} workflow={}",
+                message.getRecipient(), message.getWorkflowId());
         LOGGER.debug("Publishing message content to outbound mesh queue: {}", message);
         message.setMessageSentTimestamp(timestampService.formatInISO(timestampService.getCurrentTimestamp()));
         jmsTemplate.send(meshOutboundQueueName, session -> {

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/sequence/SequenceRepository.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/sequence/SequenceRepository.java
@@ -32,10 +32,10 @@ public class SequenceRepository {
 
     private Long increment(final String key, final Long maxSequenceNumber) {
         return Objects.requireNonNull(mongoOperations.findAndModify(
-            query(where(KEY).is(key)),
-            new Update().inc(SEQUENCE_NUMBER, 1),
-            options().returnNew(true).upsert(true),
-            OutboundSequenceId.class
+                query(where(KEY).is(key)),
+                new Update().inc(SEQUENCE_NUMBER, 1),
+                options().returnNew(true).upsert(true),
+                OutboundSequenceId.class
         )).getSequenceNumber() % maxSequenceNumber;
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/sequence/SequenceService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/sequence/SequenceService.java
@@ -25,7 +25,7 @@ public class SequenceService {
     private void validateSenderAndRecipient(final String sender, final String recipient) {
         if (StringUtils.isBlank(sender) || StringUtils.isBlank(recipient)) {
             throw new SequenceException(
-                String.format("Sender or recipient not valid. Sender: %s, recipient: %s", sender, recipient)
+                    String.format("Sender or recipient not valid. Sender: %s, recipient: %s", sender, recipient)
             );
         }
     }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/BundleMapper.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/BundleMapper.java
@@ -1,25 +1,24 @@
 package uk.nhs.digital.nhsconnect.lab.results.translator.mapper;
 
-import java.util.List;
-import java.util.Optional;
-
+import lombok.RequiredArgsConstructor;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.InstantType;
 import org.hl7.fhir.dstu3.model.Meta;
 import org.hl7.fhir.dstu3.model.UriType;
 import org.springframework.stereotype.Component;
-
-import lombok.RequiredArgsConstructor;
 import uk.nhs.digital.nhsconnect.lab.results.model.fhir.PathologyRecord;
 import uk.nhs.digital.nhsconnect.lab.results.utils.ResourceFullUrlGenerator;
 import uk.nhs.digital.nhsconnect.lab.results.utils.UUIDGenerator;
+
+import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
 public class BundleMapper {
     private static final List<UriType> BUNDLE_META_PROFILE = List.of(
-        new UriType("https://fhir.nhs.uk/STU3/StructureDefinition/ITK-Message-Bundle-1"));
+            new UriType("https://fhir.nhs.uk/STU3/StructureDefinition/ITK-Message-Bundle-1"));
     private static final String BUNDLE_IDENTIFIER_SYSTEM = "https://tools.ietf.org/html/rfc4122";
 
     private final UUIDGenerator uuidGenerator;
@@ -29,23 +28,23 @@ public class BundleMapper {
         Bundle bundle = generateInitialPathologyBundle();
 
         bundle.addEntry()
-            .setFullUrl(fullUrlGenerator.generate(pathologyRecord.getRequester()))
-            .setResource(pathologyRecord.getRequester());
+                .setFullUrl(fullUrlGenerator.generate(pathologyRecord.getRequester()))
+                .setResource(pathologyRecord.getRequester());
 
         Optional.ofNullable(pathologyRecord.getPerformer()).ifPresent(performer ->
-            bundle.addEntry()
-                .setFullUrl(fullUrlGenerator.generate(performer))
-                .setResource(performer)
+                bundle.addEntry()
+                        .setFullUrl(fullUrlGenerator.generate(performer))
+                        .setResource(performer)
         );
 
         bundle.addEntry()
-            .setFullUrl(fullUrlGenerator.generate(pathologyRecord.getPatient()))
-            .setResource(pathologyRecord.getPatient());
+                .setFullUrl(fullUrlGenerator.generate(pathologyRecord.getPatient()))
+                .setResource(pathologyRecord.getPatient());
 
         pathologyRecord.getSpecimens().forEach(specimen ->
-            bundle.addEntry()
-                .setFullUrl(fullUrlGenerator.generate(specimen))
-                .setResource(specimen));
+                bundle.addEntry()
+                        .setFullUrl(fullUrlGenerator.generate(specimen))
+                        .setResource(specimen));
 
         return bundle;
     }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/DateFormatMapper.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/DateFormatMapper.java
@@ -19,22 +19,22 @@ import static java.lang.Integer.parseInt;
 @Component
 public class DateFormatMapper {
     private static final Map<DateFormat, TemporalPrecisionEnum> FORMAT_PRECISIONS = Map.of(
-        DateFormat.CCYY, TemporalPrecisionEnum.YEAR,
-        DateFormat.CCYYMM, TemporalPrecisionEnum.MONTH,
-        DateFormat.CCYYMMDD, TemporalPrecisionEnum.DAY,
-        // MINUTE precision is not supported
-        DateFormat.CCYYMMDDHHMM, TemporalPrecisionEnum.SECOND);
+            DateFormat.CCYY, TemporalPrecisionEnum.YEAR,
+            DateFormat.CCYYMM, TemporalPrecisionEnum.MONTH,
+            DateFormat.CCYYMMDD, TemporalPrecisionEnum.DAY,
+            // MINUTE precision is not supported
+            DateFormat.CCYYMMDDHHMM, TemporalPrecisionEnum.SECOND);
 
     private static final Pattern DATE_PATTERN = Pattern.compile("^(?<yy>\\d{4})"
-        + "(?<MM>\\d{2})?"
-        + "(?<dd>\\d{2})?"
-        + "(?<hh>\\d{2})?"
-        + "(?<mm>\\d{2})?$");
+            + "(?<MM>\\d{2})?"
+            + "(?<dd>\\d{2})?"
+            + "(?<hh>\\d{2})?"
+            + "(?<mm>\\d{2})?$");
 
     public BaseDateTimeType mapToDateTimeType(final DateFormat format, final String value) {
         final var date = mapToDate(format, value);
         final var precision = Optional.ofNullable(FORMAT_PRECISIONS.get(format))
-            .orElseThrow(() -> new IllegalArgumentException("Unsupported format: " + format.getCode()));
+                .orElseThrow(() -> new IllegalArgumentException("Unsupported format: " + format.getCode()));
         return new DateTimeType(date, precision);
     }
 
@@ -51,31 +51,31 @@ public class DateFormatMapper {
             case CCYY:
                 throwIfPresent(matcher.group("MM"), "Cannot interpret " + value + " as CCYY");
                 return Date.from(LocalDate.of(yearValue, 1, 1)
-                    .atStartOfDay()
-                    .toInstant(ZoneOffset.UTC));
+                        .atStartOfDay()
+                        .toInstant(ZoneOffset.UTC));
 
             case CCYYMM:
                 throwIfPresent(matcher.group("dd"), "Cannot interpret " + value + " as CCYYMM");
                 return Date.from(LocalDate.of(yearValue, parseInt(matcher.group("MM")), 1)
-                    .atStartOfDay()
-                    .toInstant(ZoneOffset.UTC));
+                        .atStartOfDay()
+                        .toInstant(ZoneOffset.UTC));
 
             case CCYYMMDD:
                 throwIfPresent(matcher.group("hh"), "Cannot interpret " + value + " as CCYYMMDD");
                 return Date.from(LocalDate.of(
-                    yearValue,
-                    parseInt(matcher.group("MM")),
-                    parseInt(matcher.group("dd"))
+                        yearValue,
+                        parseInt(matcher.group("MM")),
+                        parseInt(matcher.group("dd"))
                 ).atStartOfDay()
-                    .toInstant(ZoneOffset.UTC));
+                        .toInstant(ZoneOffset.UTC));
 
             case CCYYMMDDHHMM:
                 return Date.from(LocalDateTime.of(
-                    yearValue,
-                    parseInt(matcher.group("MM")),
-                    parseInt(matcher.group("dd")),
-                    parseInt(matcher.group("hh")),
-                    parseInt(matcher.group("mm"))
+                        yearValue,
+                        parseInt(matcher.group("MM")),
+                        parseInt(matcher.group("dd")),
+                        parseInt(matcher.group("hh")),
+                        parseInt(matcher.group("mm"))
                 ).toInstant(ZoneOffset.UTC));
 
             default:

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PathologyRecordMapper.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PathologyRecordMapper.java
@@ -1,9 +1,8 @@
 package uk.nhs.digital.nhsconnect.lab.results.translator.mapper;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import lombok.RequiredArgsConstructor;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Message;
 import uk.nhs.digital.nhsconnect.lab.results.model.fhir.PathologyRecord;
 import uk.nhs.digital.nhsconnect.lab.results.model.fhir.PathologyRecord.PathologyRecordBuilder;

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PatientMapper.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PatientMapper.java
@@ -30,12 +30,12 @@ public class PatientMapper {
     public Patient mapToPatient(final Message message) {
 
         final Optional<InvestigationSubject> investigationSubject =
-            Optional.ofNullable(message.getServiceReportDetails())
-                .map(ServiceReportDetails::getSubject);
+                Optional.ofNullable(message.getServiceReportDetails())
+                        .map(ServiceReportDetails::getSubject);
 
         final PatientDetails patientDetails = investigationSubject
-            .map(InvestigationSubject::getDetails)
-            .orElseThrow(() -> new FhirValidationException("Unable to map message to patient details"));
+                .map(InvestigationSubject::getDetails)
+                .orElseThrow(() -> new FhirValidationException("Unable to map message to patient details"));
 
         final Patient patient = new Patient();
         patient.setId(uuidGenerator.generateUUID());
@@ -49,7 +49,7 @@ public class PatientMapper {
         mapDateOfBirth(patientDetails, patient);
 
         investigationSubject.flatMap(InvestigationSubject::getAddress)
-            .ifPresent(unstructuredAddress -> mapAddress(unstructuredAddress, patient));
+                .ifPresent(unstructuredAddress -> mapAddress(unstructuredAddress, patient));
 
         return patient;
     }
@@ -77,15 +77,15 @@ public class PatientMapper {
 
     private void mapDateOfBirth(final PatientDetails details, final Patient patient) {
         details.getDateOfBirth()
-            .map(personDateOfBirth -> new DateType(personDateOfBirth.getDateOfBirth()))
-            .ifPresent(patient::setBirthDateElement);
+                .map(personDateOfBirth -> new DateType(personDateOfBirth.getDateOfBirth()))
+                .ifPresent(patient::setBirthDateElement);
     }
 
     private void mapGender(final PatientDetails details, final Patient patient) {
         details.getSex()
-            .map(sex -> sex.getGender().name().toLowerCase())
-            .map(Enumerations.AdministrativeGender::fromCode)
-            .ifPresent(patient::setGender);
+                .map(sex -> sex.getGender().name().toLowerCase())
+                .map(Enumerations.AdministrativeGender::fromCode)
+                .ifPresent(patient::setGender);
     }
 
     private void mapName(final PersonName name, final Patient patient) {
@@ -95,7 +95,7 @@ public class PatientMapper {
         Optional.ofNullable(name.getFirstForename()).ifPresent(forename -> {
             humanName.addGiven(forename);
             Optional.ofNullable(name.getSecondForename())
-                .ifPresent(humanName::addGiven);
+                    .ifPresent(humanName::addGiven);
         });
         humanName.setFamily(name.getSurname());
 

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PractitionerMapper.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PractitionerMapper.java
@@ -1,16 +1,15 @@
 package uk.nhs.digital.nhsconnect.lab.results.translator.mapper;
 
-import java.util.Optional;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.Practitioner;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import lombok.RequiredArgsConstructor;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Message;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.segmentgroup.InvolvedParty;
 import uk.nhs.digital.nhsconnect.lab.results.utils.UUIDGenerator;
+
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor(onConstructor_ = @Autowired)
@@ -21,29 +20,29 @@ public class PractitionerMapper {
 
     public Optional<Practitioner> mapRequester(final Message message) {
         return message.getInvolvedParties().stream()
-            .map(InvolvedParty::getRequesterNameAndAddress)
-            .flatMap(Optional::stream)
-            .map(r -> mapToPractitioner(r.getIdentifier(), r.getRequesterName()))
-            .findAny();
+                .map(InvolvedParty::getRequesterNameAndAddress)
+                .flatMap(Optional::stream)
+                .map(r -> mapToPractitioner(r.getIdentifier(), r.getRequesterName()))
+                .findAny();
     }
 
     public Optional<Practitioner> mapPerformer(final Message message) {
         return message.getInvolvedParties().stream()
-            .map(InvolvedParty::getPerformerNameAndAddress)
-            .flatMap(Optional::stream)
-            .filter(p -> !StringUtils.isBlank(p.getIdentifier()))
-            .map(p -> mapToPractitioner(p.getIdentifier(), p.getPerformerName()))
-            .findAny();
+                .map(InvolvedParty::getPerformerNameAndAddress)
+                .flatMap(Optional::stream)
+                .filter(p -> !StringUtils.isBlank(p.getIdentifier()))
+                .map(p -> mapToPractitioner(p.getIdentifier(), p.getPerformerName()))
+                .findAny();
     }
 
     private Practitioner mapToPractitioner(final String identifier, final String name) {
         final var result = new Practitioner();
 
         result.addIdentifier()
-            .setValue(identifier)
-            .setSystem(SDS_USER_SYSTEM);
+                .setValue(identifier)
+                .setSystem(SDS_USER_SYSTEM);
         Optional.ofNullable(name)
-            .ifPresent(n -> result.addName().setText(n));
+                .ifPresent(n -> result.addName().setText(n));
         result.setId(uuidGenerator.generateUUID());
 
         return result;

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/SpecimenMapper.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/SpecimenMapper.java
@@ -35,8 +35,8 @@ public class SpecimenMapper {
 
     public List<Specimen> mapToSpecimens(final Message message, Patient patient) {
         return message.getServiceReportDetails().getSubject().getSpecimens().stream()
-            .map(edifact -> edifactToFhir(edifact, patient))
-            .collect(toList());
+                .map(edifact -> edifactToFhir(edifact, patient))
+                .collect(toList());
     }
 
     private Specimen edifactToFhir(final SpecimenDetails edifact, Patient patient) {
@@ -44,46 +44,46 @@ public class SpecimenMapper {
         fhir.setId(uuidGenerator.generateUUID());
         // fhir.identifier = SG16.RFF.C506.1154 (requester)
         edifact.getServiceRequesterReference()
-            .map(Reference::getNumber)
-            .ifPresent(identifier -> fhir.addIdentifier()
-                .setValue(identifier)
-                .setSystem(IDENTIFIER_SYSTEM));
+                .map(Reference::getNumber)
+                .ifPresent(identifier -> fhir.addIdentifier()
+                        .setValue(identifier)
+                        .setSystem(IDENTIFIER_SYSTEM));
         // fhir.accessionIdentifier = SG16.RFF.C506.1154 (provider)
         edifact.getServiceProviderReference()
-            .map(Reference::getNumber)
-            .ifPresent(identifier -> fhir.setAccessionIdentifier(new Identifier()
-                .setValue(identifier)
-                .setSystem(ACCESSION_IDENTIFIER_SYSTEM)));
+                .map(Reference::getNumber)
+                .ifPresent(identifier -> fhir.setAccessionIdentifier(new Identifier()
+                        .setValue(identifier)
+                        .setSystem(ACCESSION_IDENTIFIER_SYSTEM)));
         // fhir.status = [none]
         // fhir.type = SG16.SPC.C832.7866
         Optional.ofNullable(edifact.getCharacteristicType())
-            .map(SpecimenCharacteristicType::getTypeOfSpecimen)
-            .ifPresent(specimenType -> fhir.getType().addCoding()
-                .setDisplay(specimenType)
-                .setSystem(TYPE_SYSTEM));
+                .map(SpecimenCharacteristicType::getTypeOfSpecimen)
+                .ifPresent(specimenType -> fhir.getType().addCoding()
+                        .setDisplay(specimenType)
+                        .setSystem(TYPE_SYSTEM));
         // fhir.receivedTime = SG16.DTM.C507.2380 (SRI)
         edifact.getCollectionReceiptDateTime()
-            .map(date -> dateFormatMapper.mapToDate(date.getDateFormat(), date.getCollectionReceiptDateTime()))
-            .ifPresent(fhir::setReceivedTime);
+                .map(date -> dateFormatMapper.mapToDate(date.getDateFormat(), date.getCollectionReceiptDateTime()))
+                .ifPresent(fhir::setReceivedTime);
         // fhir.collection.collected = SG16.DTM.C507.2380 (SCO)
         edifact.getCollectionDateTime()
-            .map(date -> dateFormatMapper.mapToDateTimeType(date.getDateFormat(), date.getCollectionDateTime()))
-            .ifPresent(date -> fhir.getCollection().setCollected(date));
+                .map(date -> dateFormatMapper.mapToDateTimeType(date.getDateFormat(), date.getCollectionDateTime()))
+                .ifPresent(date -> fhir.getCollection().setCollected(date));
         // fhir.collection.quantity.value = SG16.QTY.C186.6060
         edifact.getQuantity().map(SpecimenQuantity::getQuantity)
-            .ifPresent(quantity -> fhir.getCollection().getQuantity().setValue(quantity));
+                .ifPresent(quantity -> fhir.getCollection().getQuantity().setValue(quantity));
         // fhir.collection.quantity.unit = SG16.QTY.C848.6410
         edifact.getQuantity().map(SpecimenQuantity::getQuantityUnitOfMeasure)
-            .ifPresent(unit -> fhir.getCollection().getQuantity().setUnit(unit));
+                .ifPresent(unit -> fhir.getCollection().getQuantity().setUnit(unit));
         // fhir.collection.bodySite = [none]
         // fhir.collection.extension[fastingStatus] = [none]
         // fhir.note = SG16.FTX.C108.4440(1-5)
         edifact.getFreeTexts().stream()
-            .map(FreeTextSegment::getTexts)
-            .flatMap(Arrays::stream)
-            .map(MappingUtils::unescape)
-            .map(text -> new Annotation().setText(text))
-            .forEach(fhir::addNote);
+                .map(FreeTextSegment::getTexts)
+                .flatMap(Arrays::stream)
+                .map(MappingUtils::unescape)
+                .map(text -> new Annotation().setText(text))
+                .forEach(fhir::addNote);
         // fhir.collection.collector = [none]
 
         // and the reference to the patient

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/utils/JmsHeaders.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/utils/JmsHeaders.java
@@ -4,5 +4,6 @@ public final class JmsHeaders {
 
     public static final String CORRELATION_ID = "CorrelationId";
 
-    private JmsHeaders() { }
+    private JmsHeaders() {
+    }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/utils/JmsReader.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/utils/JmsReader.java
@@ -10,7 +10,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public final class JmsReader {
 
-    private JmsReader() { }
+    private JmsReader() {
+    }
 
     public static String readMessage(Message message) throws JMSException {
         if (message instanceof JmsTextMessage) {

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/utils/OperationOutcomeUtils.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/utils/OperationOutcomeUtils.java
@@ -5,7 +5,8 @@ import org.hl7.fhir.dstu3.model.OperationOutcome;
 
 public final class OperationOutcomeUtils {
 
-    private OperationOutcomeUtils() { }
+    private OperationOutcomeUtils() {
+    }
 
     public static OperationOutcome createFromMessage(String message) {
         return createFromMessage(message, OperationOutcome.IssueType.UNKNOWN);

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/utils/PemFormatter.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/utils/PemFormatter.java
@@ -13,7 +13,8 @@ public final class PemFormatter {
     private static final int BODY_GROUP = 2;
     private static final int FOOTER_GROUP = 3;
 
-    private PemFormatter() { }
+    private PemFormatter() {
+    }
 
     /**
      * Different methods of importing the certificates (application.yml, ENV, Cloud secret) can affect whitespace
@@ -35,9 +36,9 @@ public final class PemFormatter {
         final String footer = matcher.group(FOOTER_GROUP).strip();
 
         body = Arrays.stream(body.split("\\s+"))
-            .map(String::strip)
-            .filter(StringUtils::isNotBlank)
-            .collect(Collectors.joining("\n"));
+                .map(String::strip)
+                .filter(StringUtils::isNotBlank)
+                .collect(Collectors.joining("\n"));
 
         return String.join("\n", header, body, footer);
     }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/utils/TimestampService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/utils/TimestampService.java
@@ -18,7 +18,7 @@ public class TimestampService {
 
     public String formatInISO(Instant timestamp) {
         return DateTimeFormatter.ISO_DATE_TIME
-            .withZone(TimestampService.UK_ZONE)
-            .format(timestamp);
+                .withZone(TimestampService.UK_ZONE)
+                .format(timestamp);
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/fixtures/EdifactFixtures.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/fixtures/EdifactFixtures.java
@@ -1,4 +1,5 @@
 package uk.nhs.digital.nhsconnect.lab.results.fixtures;
+
 import java.util.List;
 
 @SuppressWarnings("checkstyle:hideutilityclassconstructor")

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/fixtures/FhirFixtures.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/fixtures/FhirFixtures.java
@@ -1,9 +1,5 @@
 package uk.nhs.digital.nhsconnect.lab.results.fixtures;
 
-import java.util.Calendar;
-import java.util.GregorianCalendar;
-import java.util.List;
-
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.DateType;
 import org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender;
@@ -13,8 +9,11 @@ import org.hl7.fhir.dstu3.model.Meta;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Practitioner;
 import org.hl7.fhir.dstu3.model.UriType;
-
 import uk.nhs.digital.nhsconnect.lab.results.model.fhir.PathologyRecord;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.List;
 
 @SuppressWarnings("checkstyle:hideutilityclassconstructor")
 public final class FhirFixtures {
@@ -50,28 +49,28 @@ public final class FhirFixtures {
         Bundle bundle = new Bundle();
 
         bundle.setMeta(new Meta()
-            .setLastUpdatedElement(new InstantType(
-                new GregorianCalendar(YEAR, Calendar.FEBRUARY, DAY_OF_MONTH, HOUR_OF_DAY, MINUTE)
-            ))
-            .setProfile(List.of(new UriType("https://some-profile")))
+                .setLastUpdatedElement(new InstantType(
+                        new GregorianCalendar(YEAR, Calendar.FEBRUARY, DAY_OF_MONTH, HOUR_OF_DAY, MINUTE)
+                ))
+                .setProfile(List.of(new UriType("https://some-profile")))
         );
         bundle.setIdentifier(new Identifier()
-            .setSystem("https://some-system")
-            .setValue("some-value-uuid")
+                .setSystem("https://some-system")
+                .setValue("some-value-uuid")
         );
         bundle.setType(Bundle.BundleType.MESSAGE);
 
         bundle.addEntry()
-            .setFullUrl("urn:uuid:some-entry-uuid")
-            .setResource(pathologyRecord.getRequester());
+                .setFullUrl("urn:uuid:some-entry-uuid")
+                .setResource(pathologyRecord.getRequester());
 
         bundle.addEntry()
                 .setFullUrl("urn:uuid:some-entry-uuid")
                 .setResource(pathologyRecord.getPerformer());
 
         bundle.addEntry()
-            .setFullUrl("urn:uuid:some-entry-uuid")
-            .setResource(pathologyRecord.getPatient());
+                .setFullUrl("urn:uuid:some-entry-uuid")
+                .setResource(pathologyRecord.getPatient());
 
         return bundle;
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/fixtures/PathologyRecordFixtures.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/fixtures/PathologyRecordFixtures.java
@@ -2,18 +2,17 @@ package uk.nhs.digital.nhsconnect.lab.results.fixtures;
 
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Practitioner;
-
 import uk.nhs.digital.nhsconnect.lab.results.model.fhir.PathologyRecord;
 
 @SuppressWarnings("checkstyle:hideutilityclassconstructor")
 public final class PathologyRecordFixtures {
 
     public static PathologyRecord generatePathologyRecord(Practitioner requester, Practitioner performer,
-                                                        Patient patient) {
+                                                          Patient patient) {
         return PathologyRecord.builder()
-            .requester(requester)
-            .performer(performer)
-            .patient(patient)
-            .build();
+                .requester(requester)
+                .performer(performer)
+                .patient(patient)
+                .build();
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/EdifactParserTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/EdifactParserTest.java
@@ -57,7 +57,7 @@ class EdifactParserTest {
 
         // trailing empty string because we split by apostrophe and there's a trailing apostrophe
         verify(interchangeFactory).createInterchange(
-            List.of(EdifactFixtures.EDIFACT_HEADER, EdifactFixtures.EDIFACT_TRAILER, ""));
+                List.of(EdifactFixtures.EDIFACT_HEADER, EdifactFixtures.EDIFACT_TRAILER, ""));
     }
 
     @Test
@@ -71,9 +71,9 @@ class EdifactParserTest {
         when(interchangeFactory.createInterchange(any())).thenReturn(interchange);
 
         assertThatThrownBy(() ->
-            edifactParser.parse(String.join("\n", EdifactFixtures.TRAILER_BEFORE_HEADER_EDIFACT)))
-            .isInstanceOf(MessagesParsingException.class)
-            .hasMessage("Error parsing messages");
+                edifactParser.parse(String.join("\n", EdifactFixtures.TRAILER_BEFORE_HEADER_EDIFACT)))
+                .isInstanceOf(MessagesParsingException.class)
+                .hasMessage("Error parsing messages");
     }
 
     @Test
@@ -87,9 +87,9 @@ class EdifactParserTest {
         when(interchangeFactory.createInterchange(any())).thenReturn(interchange);
 
         assertThatThrownBy(() ->
-            edifactParser.parse(String.join("\n", EdifactFixtures.MISMATCH_MESSAGE_TRAILER_HEADER_EDIFACT)))
-            .isInstanceOf(MessagesParsingException.class)
-            .hasMessage("Error parsing messages");
+                edifactParser.parse(String.join("\n", EdifactFixtures.MISMATCH_MESSAGE_TRAILER_HEADER_EDIFACT)))
+                .isInstanceOf(MessagesParsingException.class)
+                .hasMessage("Error parsing messages");
     }
 
     @Test

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/InboundMessageHandlerTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/InboundMessageHandlerTest.java
@@ -61,12 +61,12 @@ class InboundMessageHandlerTest {
     @BeforeEach
     void setUp() {
         lenient().when(interchange.getInterchangeHeader()).thenReturn(
-            InterchangeHeader.builder()
-                .sender("some_sender")
-                .recipient("some_recipient")
-                .sequenceNumber(SEQUENCE_NUMBER)
-                .translationTime(Instant.now())
-                .build());
+                InterchangeHeader.builder()
+                        .sender("some_sender")
+                        .recipient("some_recipient")
+                        .sequenceNumber(SEQUENCE_NUMBER)
+                        .translationTime(Instant.now())
+                        .build());
     }
 
     @Test
@@ -74,44 +74,44 @@ class InboundMessageHandlerTest {
             throws InterchangeParsingException, MessagesParsingException {
 
         final MeshMessage meshMessage = new MeshMessage()
-            .setWorkflowId(WorkflowId.PATHOLOGY);
+                .setWorkflowId(WorkflowId.PATHOLOGY);
         when(edifactParser.parse(meshMessage.getContent())).thenThrow(InterchangeParsingException.class);
 
         final OutboundMeshMessage outboundMeshMessage = new MeshMessage()
-            .setWorkflowId(WorkflowId.PATHOLOGY_ACK);
+                .setWorkflowId(WorkflowId.PATHOLOGY_ACK);
         when(outboundMeshMessageBuilder.buildNhsAck(eq(WorkflowId.PATHOLOGY), any(InterchangeParsingException.class)))
-            .thenReturn(outboundMeshMessage);
+                .thenReturn(outboundMeshMessage);
 
         inboundMessageHandler.handle(meshMessage);
 
         assertAll(
-            () -> verify(edifactParser).parse(any()),
-            () -> verify(edifactToFhirService, never()).convertToFhir(any(Message.class)),
-            () -> verify(gpOutboundQueueService, never()).publish(any(Bundle.class)),
-            () -> verify(outboundMeshMessageBuilder, never()).buildNhsAck(any(), any(), anyList()),
-            () -> verify(meshOutboundQueueService).publish(outboundMeshMessage)
+                () -> verify(edifactParser).parse(any()),
+                () -> verify(edifactToFhirService, never()).convertToFhir(any(Message.class)),
+                () -> verify(gpOutboundQueueService, never()).publish(any(Bundle.class)),
+                () -> verify(outboundMeshMessageBuilder, never()).buildNhsAck(any(), any(), anyList()),
+                () -> verify(meshOutboundQueueService).publish(outboundMeshMessage)
         );
     }
 
     @Test
     void handleInvalidMessageMeshMessageRaisesException() throws InterchangeParsingException, MessagesParsingException {
         final MeshMessage meshMessage = new MeshMessage()
-            .setWorkflowId(WorkflowId.PATHOLOGY);
+                .setWorkflowId(WorkflowId.PATHOLOGY);
         when(edifactParser.parse(meshMessage.getContent())).thenThrow(MessagesParsingException.class);
 
         final OutboundMeshMessage outboundMeshMessage = new MeshMessage()
-            .setWorkflowId(WorkflowId.PATHOLOGY_ACK);
+                .setWorkflowId(WorkflowId.PATHOLOGY_ACK);
         when(outboundMeshMessageBuilder.buildNhsAck(eq(WorkflowId.PATHOLOGY), any(MessagesParsingException.class)))
-            .thenReturn(outboundMeshMessage);
+                .thenReturn(outboundMeshMessage);
 
         inboundMessageHandler.handle(meshMessage);
 
         assertAll(
-            () -> verify(edifactParser).parse(any()),
-            () -> verify(edifactToFhirService, never()).convertToFhir(any(Message.class)),
-            () -> verify(gpOutboundQueueService, never()).publish(any(Bundle.class)),
-            () -> verify(outboundMeshMessageBuilder, never()).buildNhsAck(any(), any(), anyList()),
-            () -> verify(meshOutboundQueueService).publish(outboundMeshMessage)
+                () -> verify(edifactParser).parse(any()),
+                () -> verify(edifactToFhirService, never()).convertToFhir(any(Message.class)),
+                () -> verify(gpOutboundQueueService, never()).publish(any(Bundle.class)),
+                () -> verify(outboundMeshMessageBuilder, never()).buildNhsAck(any(), any(), anyList()),
+                () -> verify(meshOutboundQueueService).publish(outboundMeshMessage)
         );
     }
 
@@ -120,24 +120,24 @@ class InboundMessageHandlerTest {
             throws InterchangeParsingException, MessagesParsingException {
 
         final MeshMessage meshMessage = new MeshMessage()
-            .setWorkflowId(WorkflowId.PATHOLOGY);
+                .setWorkflowId(WorkflowId.PATHOLOGY);
         when(edifactParser.parse(meshMessage.getContent())).thenReturn(interchange);
 
         final OutboundMeshMessage outboundMeshMessage = new MeshMessage()
-            .setWorkflowId(WorkflowId.PATHOLOGY_ACK);
+                .setWorkflowId(WorkflowId.PATHOLOGY_ACK);
         when(outboundMeshMessageBuilder
-            .buildNhsAck(WorkflowId.PATHOLOGY, interchange, Collections.emptyList()))
-            .thenReturn(outboundMeshMessage);
+                .buildNhsAck(WorkflowId.PATHOLOGY, interchange, Collections.emptyList()))
+                .thenReturn(outboundMeshMessage);
 
         inboundMessageHandler.handle(meshMessage);
 
         assertAll(
-            () -> verify(edifactParser).parse(any()),
-            () -> verify(edifactToFhirService, never()).convertToFhir(any(Message.class)),
-            () -> verify(gpOutboundQueueService, never()).publish(any(Bundle.class)),
-            () -> verify(outboundMeshMessageBuilder)
-                .buildNhsAck(WorkflowId.PATHOLOGY, interchange, Collections.emptyList()),
-            () -> verify(meshOutboundQueueService).publish(outboundMeshMessage)
+                () -> verify(edifactParser).parse(any()),
+                () -> verify(edifactToFhirService, never()).convertToFhir(any(Message.class)),
+                () -> verify(gpOutboundQueueService, never()).publish(any(Bundle.class)),
+                () -> verify(outboundMeshMessageBuilder)
+                        .buildNhsAck(WorkflowId.PATHOLOGY, interchange, Collections.emptyList()),
+                () -> verify(meshOutboundQueueService).publish(outboundMeshMessage)
         );
     }
 
@@ -153,17 +153,17 @@ class InboundMessageHandlerTest {
         when(edifactToFhirService.convertToFhir(message)).thenReturn(bundle);
 
         final OutboundMeshMessage outboundMeshMessage = new MeshMessage()
-            .setWorkflowId(WorkflowId.PATHOLOGY_ACK);
+                .setWorkflowId(WorkflowId.PATHOLOGY_ACK);
         when(outboundMeshMessageBuilder.buildNhsAck(any(), eq(interchange), anyList())).thenReturn(outboundMeshMessage);
 
         inboundMessageHandler.handle(meshMessage);
 
         assertAll(
-            () -> verify(edifactParser).parse(any()),
-            () -> verify(edifactToFhirService).convertToFhir(message),
-            () -> verify(gpOutboundQueueService).publish(any(Bundle.class)),
-            () -> verify(outboundMeshMessageBuilder).buildNhsAck(any(), eq(interchange), anyList()),
-            () -> verify(meshOutboundQueueService).publish(outboundMeshMessage)
+                () -> verify(edifactParser).parse(any()),
+                () -> verify(edifactToFhirService).convertToFhir(message),
+                () -> verify(gpOutboundQueueService).publish(any(Bundle.class)),
+                () -> verify(outboundMeshMessageBuilder).buildNhsAck(any(), eq(interchange), anyList()),
+                () -> verify(meshOutboundQueueService).publish(outboundMeshMessage)
         );
     }
 
@@ -181,18 +181,18 @@ class InboundMessageHandlerTest {
         when(edifactToFhirService.convertToFhir(message1)).thenReturn(bundle);
 
         final OutboundMeshMessage outboundMeshMessage = new MeshMessage()
-            .setWorkflowId(WorkflowId.PATHOLOGY_ACK);
+                .setWorkflowId(WorkflowId.PATHOLOGY_ACK);
         when(outboundMeshMessageBuilder.buildNhsAck(any(), eq(interchange), anyList())).thenReturn(outboundMeshMessage);
 
         inboundMessageHandler.handle(meshMessage);
 
         assertAll(
-            () -> verify(edifactParser).parse(any()),
-            () -> verify(edifactToFhirService).convertToFhir(message),
-            () -> verify(edifactToFhirService).convertToFhir(message1),
-            () -> verify(gpOutboundQueueService, times(2)).publish(any(Bundle.class)),
-            () -> verify(outboundMeshMessageBuilder).buildNhsAck(any(), eq(interchange), anyList()),
-            () -> verify(meshOutboundQueueService).publish(outboundMeshMessage)
+                () -> verify(edifactParser).parse(any()),
+                () -> verify(edifactToFhirService).convertToFhir(message),
+                () -> verify(edifactToFhirService).convertToFhir(message1),
+                () -> verify(gpOutboundQueueService, times(2)).publish(any(Bundle.class)),
+                () -> verify(outboundMeshMessageBuilder).buildNhsAck(any(), eq(interchange), anyList()),
+                () -> verify(meshOutboundQueueService).publish(outboundMeshMessage)
         );
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/fhir/EdifactToFhirServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/fhir/EdifactToFhirServiceTest.java
@@ -40,9 +40,9 @@ class EdifactToFhirServiceTest {
         final Bundle bundle = service.convertToFhir(message);
 
         assertAll(
-            () -> assertThat(bundle).isSameAs(generatedBundle),
-            () -> verifyNoInteractions(pathologyRecord),
-            () -> verifyNoInteractions(generatedBundle)
+                () -> assertThat(bundle).isSameAs(generatedBundle),
+                () -> verifyNoInteractions(pathologyRecord),
+                () -> verifyNoInteractions(generatedBundle)
         );
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/queue/MeshInboundQueueServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/queue/MeshInboundQueueServiceTest.java
@@ -78,10 +78,10 @@ class MeshInboundQueueServiceTest {
         expectedMeshMessage.setWorkflowId(WorkflowId.PATHOLOGY);
 
         assertAll(
-            () -> verify(correlationIdService).applyCorrelationId(CORRELATION_ID),
-            () -> verify(inboundMessageHandler).handle(expectedMeshMessage),
-            () -> verify(message).acknowledge(),
-            () -> verify(correlationIdService).resetCorrelationId()
+                () -> verify(correlationIdService).applyCorrelationId(CORRELATION_ID),
+                () -> verify(inboundMessageHandler).handle(expectedMeshMessage),
+                () -> verify(message).acknowledge(),
+                () -> verify(correlationIdService).resetCorrelationId()
         );
     }
 
@@ -93,9 +93,9 @@ class MeshInboundQueueServiceTest {
         assertThrows(Exception.class, () -> meshInboundQueueService.receive(message));
 
         assertAll(
-            () -> verify(correlationIdService).applyCorrelationId(CORRELATION_ID),
-            () -> verify(message, never()).acknowledge(),
-            () -> verify(correlationIdService).resetCorrelationId()
+                () -> verify(correlationIdService).applyCorrelationId(CORRELATION_ID),
+                () -> verify(message, never()).acknowledge(),
+                () -> verify(correlationIdService).resetCorrelationId()
         );
     }
 
@@ -108,9 +108,9 @@ class MeshInboundQueueServiceTest {
         assertThrows(RuntimeException.class, () -> meshInboundQueueService.receive(message));
 
         assertAll(
-            () -> verify(correlationIdService).applyCorrelationId(CORRELATION_ID),
-            () -> verify(message, never()).acknowledge(),
-            () -> verify(correlationIdService).resetCorrelationId()
+                () -> verify(correlationIdService).applyCorrelationId(CORRELATION_ID),
+                () -> verify(message, never()).acknowledge(),
+                () -> verify(correlationIdService).resetCorrelationId()
         );
     }
 
@@ -120,14 +120,14 @@ class MeshInboundQueueServiceTest {
         when(message.getBody(String.class)).thenReturn("{\"workflowId\":\"" + SCREENING_WORKFLOW_ID + "\"}");
 
         final UnknownWorkflowException exception =
-            assertThrows(UnknownWorkflowException.class, () -> meshInboundQueueService.receive(message));
+                assertThrows(UnknownWorkflowException.class, () -> meshInboundQueueService.receive(message));
 
         assertEquals("Unknown workflow id: " + SCREENING_WORKFLOW_ID, exception.getMessage());
 
         assertAll(
-            () -> verify(correlationIdService).applyCorrelationId(CORRELATION_ID),
-            () -> verify(message, never()).acknowledge(),
-            () -> verify(correlationIdService).resetCorrelationId()
+                () -> verify(correlationIdService).applyCorrelationId(CORRELATION_ID),
+                () -> verify(message, never()).acknowledge(),
+                () -> verify(correlationIdService).resetCorrelationId()
         );
     }
 
@@ -142,10 +142,10 @@ class MeshInboundQueueServiceTest {
         expectedMeshMessage.setWorkflowId(WorkflowId.PATHOLOGY);
 
         assertAll(
-            () -> verify(correlationIdService, never()).applyCorrelationId(CORRELATION_ID),
-            () -> verify(inboundMessageHandler).handle(expectedMeshMessage),
-            () -> verify(message).acknowledge(),
-            () -> verify(correlationIdService).resetCorrelationId()
+                () -> verify(correlationIdService, never()).applyCorrelationId(CORRELATION_ID),
+                () -> verify(inboundMessageHandler).handle(expectedMeshMessage),
+                () -> verify(message).acknowledge(),
+                () -> verify(correlationIdService).resetCorrelationId()
         );
     }
 
@@ -157,14 +157,14 @@ class MeshInboundQueueServiceTest {
         when(timestampService.formatInISO(now)).thenReturn(messageSentTimestamp);
 
         final InboundMeshMessage inboundMeshMessage = InboundMeshMessage.create(WorkflowId.PATHOLOGY,
-            "ASDF", null, "ID123");
+                "ASDF", null, "ID123");
 
         meshInboundQueueService.publish(inboundMeshMessage);
 
         // the method parameter is modified so another copy is needed. Timestamp set to expected value
         final InboundMeshMessage expectedInboundMeshMessage = InboundMeshMessage.create(WorkflowId.PATHOLOGY,
-            "ASDF", messageSentTimestamp,
-            "ID123");
+                "ASDF", messageSentTimestamp,
+                "ID123");
         final String expectedStringMessage = objectMapper.writeValueAsString(expectedInboundMeshMessage);
         verify(jmsTemplate).send((String) isNull(), jmsMessageCreatorCaptor.capture());
         final MessageCreator messageCreator = jmsMessageCreatorCaptor.getValue();

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/mesh/MeshServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/mesh/MeshServiceTest.java
@@ -81,15 +81,15 @@ class MeshServiceTest {
         meshService.scanMeshInboxForMessages();
 
         assertAll(
-            () -> verify(meshClient).authenticate(),
-            () -> verify(meshClient).getEdifactMessage(MESSAGE_ID1),
-            () -> verify(meshInboundQueueService).publish(meshMessage1),
-            () -> verify(meshClient).acknowledgeMessage(MESSAGE_ID1),
-            () -> verify(meshClient).getEdifactMessage(MESSAGE_ID2),
-            () -> verify(meshInboundQueueService).publish(meshMessage1),
-            () -> verify(meshClient).acknowledgeMessage(MESSAGE_ID2),
-            () -> verify(correlationIdService, times(2)).applyRandomCorrelationId(),
-            () -> verify(correlationIdService, times(2)).resetCorrelationId()
+                () -> verify(meshClient).authenticate(),
+                () -> verify(meshClient).getEdifactMessage(MESSAGE_ID1),
+                () -> verify(meshInboundQueueService).publish(meshMessage1),
+                () -> verify(meshClient).acknowledgeMessage(MESSAGE_ID1),
+                () -> verify(meshClient).getEdifactMessage(MESSAGE_ID2),
+                () -> verify(meshInboundQueueService).publish(meshMessage1),
+                () -> verify(meshClient).acknowledgeMessage(MESSAGE_ID2),
+                () -> verify(correlationIdService, times(2)).applyRandomCorrelationId(),
+                () -> verify(correlationIdService, times(2)).resetCorrelationId()
         );
     }
 
@@ -107,14 +107,14 @@ class MeshServiceTest {
         meshService.scanMeshInboxForMessages();
 
         assertAll(
-            () -> verify(meshClient).authenticate(),
-            () -> verify(meshClient).getEdifactMessage(MESSAGE_ID1),
-            () -> verify(meshInboundQueueService).publish(meshMessage1),
-            () -> verify(meshClient).acknowledgeMessage(MESSAGE_ID1),
-            // second message not downloaded and published
-            () -> verifyNoMoreInteractions(meshClient, meshInboundQueueService),
-            () -> verify(correlationIdService).applyRandomCorrelationId(),
-            () -> verify(correlationIdService).resetCorrelationId()
+                () -> verify(meshClient).authenticate(),
+                () -> verify(meshClient).getEdifactMessage(MESSAGE_ID1),
+                () -> verify(meshInboundQueueService).publish(meshMessage1),
+                () -> verify(meshClient).acknowledgeMessage(MESSAGE_ID1),
+                // second message not downloaded and published
+                () -> verifyNoMoreInteractions(meshClient, meshInboundQueueService),
+                () -> verify(correlationIdService).applyRandomCorrelationId(),
+                () -> verify(correlationIdService).resetCorrelationId()
         );
     }
 
@@ -125,13 +125,13 @@ class MeshServiceTest {
         when(meshClient.getInboxMessageIds()).thenThrow(new MeshApiConnectionException("error"));
 
         assertAll(
-            () -> assertThatThrownBy(meshService::scanMeshInboxForMessages)
-                .isExactlyInstanceOf(MeshApiConnectionException.class),
-            () -> verify(meshClient).authenticate(),
-            () -> verify(meshClient, never()).getEdifactMessage(any()),
-            () -> verify(meshInboundQueueService, never()).publish(any()),
-            () -> verify(meshClient, never()).acknowledgeMessage(any()),
-            () -> verifyNoInteractions(correlationIdService)
+                () -> assertThatThrownBy(meshService::scanMeshInboxForMessages)
+                        .isExactlyInstanceOf(MeshApiConnectionException.class),
+                () -> verify(meshClient).authenticate(),
+                () -> verify(meshClient, never()).getEdifactMessage(any()),
+                () -> verify(meshInboundQueueService, never()).publish(any()),
+                () -> verify(meshClient, never()).acknowledgeMessage(any()),
+                () -> verifyNoInteractions(correlationIdService)
         );
     }
 
@@ -145,13 +145,13 @@ class MeshServiceTest {
         meshService.scanMeshInboxForMessages();
 
         assertAll(
-            () -> verify(meshClient).authenticate(),
-            () -> verify(meshClient).getEdifactMessage(ERROR_MESSAGE_ID),
-            () -> verify(meshInboundQueueService, never()).publish(any()),
-            () -> verify(meshClient, never()).acknowledgeMessage(MESSAGE_ID1),
+                () -> verify(meshClient).authenticate(),
+                () -> verify(meshClient).getEdifactMessage(ERROR_MESSAGE_ID),
+                () -> verify(meshInboundQueueService, never()).publish(any()),
+                () -> verify(meshClient, never()).acknowledgeMessage(MESSAGE_ID1),
 
-            () -> verify(correlationIdService).applyRandomCorrelationId(),
-            () -> verify(correlationIdService).resetCorrelationId()
+                () -> verify(correlationIdService).applyRandomCorrelationId(),
+                () -> verify(correlationIdService).resetCorrelationId()
         );
     }
 
@@ -165,12 +165,12 @@ class MeshServiceTest {
         meshService.scanMeshInboxForMessages();
 
         assertAll(
-            () -> verify(meshClient).authenticate(),
-            () -> verify(meshClient).getEdifactMessage(ERROR_MESSAGE_ID),
-            () -> verify(meshInboundQueueService, never()).publish(any()),
-            () -> verify(meshClient, never()).acknowledgeMessage(MESSAGE_ID1),
-            () -> verify(correlationIdService).applyRandomCorrelationId(),
-            () -> verify(correlationIdService).resetCorrelationId()
+                () -> verify(meshClient).authenticate(),
+                () -> verify(meshClient).getEdifactMessage(ERROR_MESSAGE_ID),
+                () -> verify(meshInboundQueueService, never()).publish(any()),
+                () -> verify(meshClient, never()).acknowledgeMessage(MESSAGE_ID1),
+                () -> verify(correlationIdService).applyRandomCorrelationId(),
+                () -> verify(correlationIdService).resetCorrelationId()
         );
     }
 
@@ -185,13 +185,13 @@ class MeshServiceTest {
         meshService.scanMeshInboxForMessages();
 
         assertAll(
-            () -> verify(meshClient).authenticate(),
-            () -> verify(meshClient).getEdifactMessage(ERROR_MESSAGE_ID),
-            () -> verify(meshClient).getEdifactMessage(MESSAGE_ID1),
-            () -> verify(meshInboundQueueService).publish(meshMessage1),
-            () -> verify(meshClient).acknowledgeMessage(MESSAGE_ID1),
-            () -> verify(correlationIdService, times(2)).applyRandomCorrelationId(),
-            () -> verify(correlationIdService, times(2)).resetCorrelationId()
+                () -> verify(meshClient).authenticate(),
+                () -> verify(meshClient).getEdifactMessage(ERROR_MESSAGE_ID),
+                () -> verify(meshClient).getEdifactMessage(MESSAGE_ID1),
+                () -> verify(meshInboundQueueService).publish(meshMessage1),
+                () -> verify(meshClient).acknowledgeMessage(MESSAGE_ID1),
+                () -> verify(correlationIdService, times(2)).applyRandomCorrelationId(),
+                () -> verify(correlationIdService, times(2)).resetCorrelationId()
         );
     }
 
@@ -211,15 +211,15 @@ class MeshServiceTest {
         meshService.scanMeshInboxForMessages();
 
         assertAll(
-            () -> verify(meshClient).authenticate(),
-            () -> verify(meshClient).getEdifactMessage(ERROR_MESSAGE_ID),
-            () -> verify(meshClient).getEdifactMessage(MESSAGE_ID1),
-            () -> verify(meshInboundQueueService).publish(messageForAckError),
-            () -> verify(meshInboundQueueService).publish(meshMessage1),
-            () -> verify(meshClient).acknowledgeMessage(ERROR_MESSAGE_ID),
-            () -> verify(meshClient).acknowledgeMessage(MESSAGE_ID1),
-            () -> verify(correlationIdService, times(2)).applyRandomCorrelationId(),
-            () -> verify(correlationIdService, times(2)).resetCorrelationId()
+                () -> verify(meshClient).authenticate(),
+                () -> verify(meshClient).getEdifactMessage(ERROR_MESSAGE_ID),
+                () -> verify(meshClient).getEdifactMessage(MESSAGE_ID1),
+                () -> verify(meshInboundQueueService).publish(messageForAckError),
+                () -> verify(meshInboundQueueService).publish(meshMessage1),
+                () -> verify(meshClient).acknowledgeMessage(ERROR_MESSAGE_ID),
+                () -> verify(meshClient).acknowledgeMessage(MESSAGE_ID1),
+                () -> verify(correlationIdService, times(2)).applyRandomCorrelationId(),
+                () -> verify(correlationIdService, times(2)).resetCorrelationId()
         );
     }
 
@@ -234,12 +234,12 @@ class MeshServiceTest {
         meshService.scanMeshInboxForMessages();
 
         assertAll(
-            () -> verify(meshClient).authenticate(),
-            () -> verify(meshClient).getEdifactMessage(MESSAGE_ID1),
-            () -> verify(meshInboundQueueService).publish(meshMessage1),
-            () -> verify(meshClient, never()).acknowledgeMessage(MESSAGE_ID1),
-            () -> verify(correlationIdService).applyRandomCorrelationId(),
-            () -> verify(correlationIdService).resetCorrelationId()
+                () -> verify(meshClient).authenticate(),
+                () -> verify(meshClient).getEdifactMessage(MESSAGE_ID1),
+                () -> verify(meshInboundQueueService).publish(meshMessage1),
+                () -> verify(meshClient, never()).acknowledgeMessage(MESSAGE_ID1),
+                () -> verify(correlationIdService).applyRandomCorrelationId(),
+                () -> verify(correlationIdService).resetCorrelationId()
         );
     }
 
@@ -264,9 +264,9 @@ class MeshServiceTest {
         meshService.scanMeshInboxForMessages();
 
         assertAll(
-            () -> verify(meshClient).authenticate(),
-            () -> verify(meshClient, never()).getEdifactMessage(MESSAGE_ID1),
-            () -> verifyNoInteractions(meshInboundQueueService)
+                () -> verify(meshClient).authenticate(),
+                () -> verify(meshClient, never()).getEdifactMessage(MESSAGE_ID1),
+                () -> verifyNoInteractions(meshInboundQueueService)
         );
     }
 
@@ -281,9 +281,9 @@ class MeshServiceTest {
                 .isExactlyInstanceOf(MeshApiConnectionException.class);
 
         assertAll(
-            () -> verify(meshClient).authenticate(),
-            () -> verifyNoMoreInteractions(meshClient),
-            () -> verifyNoInteractions(meshInboundQueueService)
+                () -> verify(meshClient).authenticate(),
+                () -> verifyNoMoreInteractions(meshClient),
+                () -> verifyNoInteractions(meshInboundQueueService)
         );
     }
 
@@ -294,9 +294,9 @@ class MeshServiceTest {
         meshService.scanMeshInboxForMessages();
 
         assertAll(
-            () -> verify(meshMailBoxScheduler, never()).hasTimePassed(scanDelayInSeconds),
-            () -> verify(meshClient, never()).getEdifactMessage(MESSAGE_ID1),
-            () -> verifyNoInteractions(meshInboundQueueService)
+                () -> verify(meshMailBoxScheduler, never()).hasTimePassed(scanDelayInSeconds),
+                () -> verify(meshClient, never()).getEdifactMessage(MESSAGE_ID1),
+                () -> verifyNoInteractions(meshInboundQueueService)
         );
     }
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/mesh/RecipientMailboxIdMappingsTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/mesh/RecipientMailboxIdMappingsTest.java
@@ -16,7 +16,7 @@ public class RecipientMailboxIdMappingsTest {
     @BeforeEach
     void setUp() {
         recipientMailboxIdMappings = new RecipientMailboxIdMappings(
-            "REC1=test_mailbox REC2=test_mailbox REC3=test_mailbox");
+                "REC1=test_mailbox REC2=test_mailbox REC3=test_mailbox");
     }
 
     @Test
@@ -33,7 +33,7 @@ public class RecipientMailboxIdMappingsTest {
         final OutboundMeshMessage message = new MeshMessage().setRecipient("INVALID");
 
         final MeshRecipientUnknownException exception = assertThrows(MeshRecipientUnknownException.class,
-            () -> recipientMailboxIdMappings.getRecipientMailboxId(message));
+                () -> recipientMailboxIdMappings.getRecipientMailboxId(message));
 
         assertEquals("Couldn't decode recipient: INVALID", exception.getMessage());
     }
@@ -46,10 +46,10 @@ public class RecipientMailboxIdMappingsTest {
         final OutboundMeshMessage message = new MeshMessage();
 
         final MeshRecipientUnknownException exception = assertThrows(MeshRecipientUnknownException.class,
-            () -> recipientMailboxIdMappings.getRecipientMailboxId(message));
+                () -> recipientMailboxIdMappings.getRecipientMailboxId(message));
 
         assertEquals("LAB_RESULTS_MESH_RECIPIENT_MAILBOX_ID_MAPPINGS env var doesn't contain valid "
-            + "recipient to mailbox mapping", exception.getMessage());
+                + "recipient to mailbox mapping", exception.getMessage());
     }
 
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/mesh/http/FakeMeshConfig.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/mesh/http/FakeMeshConfig.java
@@ -3,12 +3,12 @@ package uk.nhs.digital.nhsconnect.lab.results.mesh.http;
 public class FakeMeshConfig extends MeshConfig {
     public FakeMeshConfig() {
         super("mailboxId",
-            "password",
-            "SharedKey",
-            System.getProperty("LAB_RESULTS_MESH_HOST"),
-            "false",
-            System.getProperty("LAB_RESULTS_MESH_ENDPOINT_CERT"),
-            System.getProperty("LAB_RESULTS_MESH_ENDPOINT_KEY"),
-            System.getProperty("LAB_RESULTS_MESH_SUB_CA"));
+                "password",
+                "SharedKey",
+                System.getProperty("LAB_RESULTS_MESH_HOST"),
+                "false",
+                System.getProperty("LAB_RESULTS_MESH_ENDPOINT_CERT"),
+                System.getProperty("LAB_RESULTS_MESH_ENDPOINT_KEY"),
+                System.getProperty("LAB_RESULTS_MESH_SUB_CA"));
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/mesh/http/MeshHeadersTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/mesh/http/MeshHeadersTest.java
@@ -38,21 +38,21 @@ class MeshHeadersTest {
         final Header[] headers = meshHeaders.createSendHeaders(meshRecipient, WorkflowId.PATHOLOGY);
 
         final List<String> headerNames = Arrays.stream(headers)
-            .map(BasicHeader.class::cast)
-            .map(BasicHeader::getName)
-            .collect(Collectors.toList());
+                .map(BasicHeader.class::cast)
+                .map(BasicHeader::getName)
+                .collect(Collectors.toList());
         assertThat(headerNames).containsExactlyInAnyOrder(
-            HEADER_MEX_CLIENT_VERSION,
-            HEADER_MEX_OS_VERSION,
-            HEADER_MEX_OS_NAME,
-            HEADER_AUTHORIZATION,
-            HEADER_MEX_FROM,
-            HEADER_MEX_TO,
-            HEADER_MEX_WORKFLOW_ID,
-            HEADER_MEX_FILE_NAME,
-            HEADER_MEX_MESSAGE_TYPE,
-            HEADER_MEX_CONTENT_COMPRESSED,
-            HEADER_CONTENT_TYPE);
+                HEADER_MEX_CLIENT_VERSION,
+                HEADER_MEX_OS_VERSION,
+                HEADER_MEX_OS_NAME,
+                HEADER_AUTHORIZATION,
+                HEADER_MEX_FROM,
+                HEADER_MEX_TO,
+                HEADER_MEX_WORKFLOW_ID,
+                HEADER_MEX_FILE_NAME,
+                HEADER_MEX_MESSAGE_TYPE,
+                HEADER_MEX_CONTENT_COMPRESSED,
+                HEADER_CONTENT_TYPE);
 
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(getHeaderValue(headers, HEADER_MEX_CLIENT_VERSION)).isNotBlank();
@@ -62,7 +62,7 @@ class MeshHeadersTest {
             softly.assertThat(getHeaderValue(headers, HEADER_MEX_FROM)).isEqualTo("mailboxId");
             softly.assertThat(getHeaderValue(headers, HEADER_MEX_TO)).isEqualTo(meshRecipient);
             softly.assertThat(getHeaderValue(headers, HEADER_MEX_WORKFLOW_ID))
-                .isEqualTo(WorkflowId.PATHOLOGY.toString());
+                    .isEqualTo(WorkflowId.PATHOLOGY.toString());
             softly.assertThat(getHeaderValue(headers, HEADER_MEX_FILE_NAME)).isEqualTo("edifact.dat");
             softly.assertThat(getHeaderValue(headers, HEADER_MEX_MESSAGE_TYPE)).isEqualTo("DATA");
             softly.assertThat(getHeaderValue(headers, HEADER_MEX_CONTENT_COMPRESSED)).isEqualTo("N");
@@ -75,14 +75,14 @@ class MeshHeadersTest {
         final Header[] headers = meshHeaders.createMinimalHeaders();
 
         final List<String> headerNames = Arrays.stream(headers)
-            .map(BasicHeader.class::cast)
-            .map(BasicHeader::getName)
-            .collect(Collectors.toList());
+                .map(BasicHeader.class::cast)
+                .map(BasicHeader::getName)
+                .collect(Collectors.toList());
         assertThat(headerNames).containsExactlyInAnyOrder(
-            HEADER_MEX_CLIENT_VERSION,
-            HEADER_MEX_OS_VERSION,
-            HEADER_MEX_OS_NAME,
-            HEADER_AUTHORIZATION);
+                HEADER_MEX_CLIENT_VERSION,
+                HEADER_MEX_OS_VERSION,
+                HEADER_MEX_OS_NAME,
+                HEADER_AUTHORIZATION);
 
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(getHeaderValue(headers, HEADER_MEX_CLIENT_VERSION)).isNotBlank();
@@ -97,16 +97,16 @@ class MeshHeadersTest {
         final Header[] headers = meshHeaders.createAuthenticateHeaders();
 
         final List<String> headerNames = Arrays.stream(headers)
-            .map(BasicHeader.class::cast)
-            .map(BasicHeader::getName)
-            .collect(Collectors.toList());
+                .map(BasicHeader.class::cast)
+                .map(BasicHeader::getName)
+                .collect(Collectors.toList());
         assertThat(headerNames).containsExactlyInAnyOrder(
-            HEADER_MEX_JAVA_VERSION,
-            HEADER_MEX_OS_ARCHITECTURE,
-            HEADER_MEX_CLIENT_VERSION,
-            HEADER_MEX_OS_VERSION,
-            HEADER_MEX_OS_NAME,
-            HEADER_AUTHORIZATION);
+                HEADER_MEX_JAVA_VERSION,
+                HEADER_MEX_OS_ARCHITECTURE,
+                HEADER_MEX_CLIENT_VERSION,
+                HEADER_MEX_OS_VERSION,
+                HEADER_MEX_OS_NAME,
+                HEADER_AUTHORIZATION);
 
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(getHeaderValue(headers, HEADER_MEX_JAVA_VERSION)).isNotBlank();
@@ -120,10 +120,10 @@ class MeshHeadersTest {
 
     private String getHeaderValue(Header[] headers, String header) {
         return Arrays.stream(headers)
-            .map(BasicHeader.class::cast)
-            .filter(h -> header.equals(h.getName()))
-            .findFirst()
-            .map(BasicHeader::getValue)
-            .orElseThrow();
+                .map(BasicHeader.class::cast)
+                .filter(h -> header.equals(h.getName()))
+                .findFirst()
+                .map(BasicHeader::getValue)
+                .orElseThrow();
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/mesh/message/WorkflowIdTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/mesh/message/WorkflowIdTest.java
@@ -12,35 +12,35 @@ class WorkflowIdTest {
     @Test
     void testFromStringReturnsWorkflowIdForValidWorkflowIdString() {
         assertAll(
-            () -> assertEquals(WorkflowId.PATHOLOGY,
-                WorkflowId.fromString(WorkflowId.PATHOLOGY.getWorkflowId())),
-            () -> assertEquals(WorkflowId.PATHOLOGY_ACK,
-                WorkflowId.fromString(WorkflowId.PATHOLOGY_ACK.getWorkflowId())),
-            () -> assertEquals(WorkflowId.SCREENING,
-                WorkflowId.fromString(WorkflowId.SCREENING.getWorkflowId())),
-            () -> assertEquals(WorkflowId.SCREENING_ACK,
-                WorkflowId.fromString(WorkflowId.SCREENING_ACK.getWorkflowId()))
+                () -> assertEquals(WorkflowId.PATHOLOGY,
+                        WorkflowId.fromString(WorkflowId.PATHOLOGY.getWorkflowId())),
+                () -> assertEquals(WorkflowId.PATHOLOGY_ACK,
+                        WorkflowId.fromString(WorkflowId.PATHOLOGY_ACK.getWorkflowId())),
+                () -> assertEquals(WorkflowId.SCREENING,
+                        WorkflowId.fromString(WorkflowId.SCREENING.getWorkflowId())),
+                () -> assertEquals(WorkflowId.SCREENING_ACK,
+                        WorkflowId.fromString(WorkflowId.SCREENING_ACK.getWorkflowId()))
         );
     }
 
     @Test
     void testFromStringReturnsWorkflowIdForValidLowercaseWorkflowIdString() {
         assertAll(
-            () -> assertEquals(WorkflowId.PATHOLOGY,
-                WorkflowId.fromString(WorkflowId.PATHOLOGY.getWorkflowId().toLowerCase())),
-            () -> assertEquals(WorkflowId.PATHOLOGY_ACK,
-                WorkflowId.fromString(WorkflowId.PATHOLOGY_ACK.getWorkflowId().toLowerCase())),
-            () -> assertEquals(WorkflowId.SCREENING,
-                WorkflowId.fromString(WorkflowId.SCREENING.getWorkflowId().toLowerCase())),
-            () -> assertEquals(WorkflowId.SCREENING_ACK,
-                WorkflowId.fromString(WorkflowId.SCREENING_ACK.getWorkflowId().toLowerCase()))
+                () -> assertEquals(WorkflowId.PATHOLOGY,
+                        WorkflowId.fromString(WorkflowId.PATHOLOGY.getWorkflowId().toLowerCase())),
+                () -> assertEquals(WorkflowId.PATHOLOGY_ACK,
+                        WorkflowId.fromString(WorkflowId.PATHOLOGY_ACK.getWorkflowId().toLowerCase())),
+                () -> assertEquals(WorkflowId.SCREENING,
+                        WorkflowId.fromString(WorkflowId.SCREENING.getWorkflowId().toLowerCase())),
+                () -> assertEquals(WorkflowId.SCREENING_ACK,
+                        WorkflowId.fromString(WorkflowId.SCREENING_ACK.getWorkflowId().toLowerCase()))
         );
     }
 
     @Test
     void testFromStringThrowsExceptionForInvalidWorkflowIdString() {
         final MeshWorkflowUnknownException exception = assertThrows(MeshWorkflowUnknownException.class,
-            () -> WorkflowId.fromString("INVALID"));
+                () -> WorkflowId.fromString("INVALID"));
         assertEquals("Unsupported workflow id INVALID", exception.getMessage());
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/mesh/scheduler/SchedulerTimestampRepositoryExtensionTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/mesh/scheduler/SchedulerTimestampRepositoryExtensionTest.java
@@ -49,12 +49,12 @@ class SchedulerTimestampRepositoryExtensionTest {
         when(timestampService.getCurrentTimestamp()).thenReturn(timestamp);
 
         final boolean updated = schedulerTimestampRepositoryExtensions.updateTimestamp(
-            SCHEDULER_TYPE, timestamp, SECONDS);
+                SCHEDULER_TYPE, timestamp, SECONDS);
         final var expected = new SchedulerTimestamp(SCHEDULER_TYPE, timestamp);
 
         assertAll(
-            () -> assertThat(updated).isFalse(),
-            () -> verify(mongoOperations).save(expected, MESH_TIMESTAMP_COLLECTION_NAME)
+                () -> assertThat(updated).isFalse(),
+                () -> verify(mongoOperations).save(expected, MESH_TIMESTAMP_COLLECTION_NAME)
         );
     }
 
@@ -66,7 +66,7 @@ class SchedulerTimestampRepositoryExtensionTest {
         when(mongoOperations.save(any(), eq(MESH_TIMESTAMP_COLLECTION_NAME))).thenThrow(exception);
 
         final boolean updated = schedulerTimestampRepositoryExtensions.updateTimestamp(
-            SCHEDULER_TYPE, Instant.now(), SECONDS);
+                SCHEDULER_TYPE, Instant.now(), SECONDS);
 
         assertThat(updated).isFalse();
     }
@@ -79,7 +79,7 @@ class SchedulerTimestampRepositoryExtensionTest {
         when(mongoOperations.save(any(), eq(MESH_TIMESTAMP_COLLECTION_NAME))).thenThrow(exception);
 
         final boolean updated = schedulerTimestampRepositoryExtensions.updateTimestamp(
-            SCHEDULER_TYPE, Instant.now(), SECONDS);
+                SCHEDULER_TYPE, Instant.now(), SECONDS);
 
         assertThat(updated).isFalse();
     }
@@ -89,12 +89,12 @@ class SchedulerTimestampRepositoryExtensionTest {
         when(mongoOperations.count(any(Query.class), eq(MESH_TIMESTAMP_COLLECTION_NAME))).thenReturn(1L);
 
         when(mongoOperations.updateFirst(any(Query.class), any(UpdateDefinition.class), any(String.class)))
-            .thenReturn(updateResult);
+                .thenReturn(updateResult);
         when(updateResult.getModifiedCount()).thenReturn(1L);
         when(timestampService.getCurrentTimestamp()).thenReturn(Instant.now());
 
         final boolean updated = schedulerTimestampRepositoryExtensions.updateTimestamp(
-            SCHEDULER_TYPE, Instant.now(), SECONDS);
+                SCHEDULER_TYPE, Instant.now(), SECONDS);
 
         assertThat(updated).isTrue();
     }
@@ -104,12 +104,12 @@ class SchedulerTimestampRepositoryExtensionTest {
         when(mongoOperations.count(any(Query.class), eq(MESH_TIMESTAMP_COLLECTION_NAME))).thenReturn(2L);
 
         when(mongoOperations.updateFirst(any(Query.class), any(UpdateDefinition.class), any(String.class)))
-            .thenReturn(updateResult);
+                .thenReturn(updateResult);
         when(updateResult.getModifiedCount()).thenReturn(1L);
         when(timestampService.getCurrentTimestamp()).thenReturn(Instant.now());
 
         final boolean updated = schedulerTimestampRepositoryExtensions.updateTimestamp(
-            SCHEDULER_TYPE, Instant.now(), SECONDS);
+                SCHEDULER_TYPE, Instant.now(), SECONDS);
 
         assertThat(updated).isTrue();
     }
@@ -119,12 +119,12 @@ class SchedulerTimestampRepositoryExtensionTest {
         when(mongoOperations.count(any(Query.class), eq(MESH_TIMESTAMP_COLLECTION_NAME))).thenReturn(1L);
 
         when(mongoOperations.updateFirst(any(Query.class), any(UpdateDefinition.class), any(String.class)))
-            .thenReturn(updateResult);
+                .thenReturn(updateResult);
         when(updateResult.getModifiedCount()).thenReturn(0L);
         when(timestampService.getCurrentTimestamp()).thenReturn(Instant.now());
 
         final boolean updated = schedulerTimestampRepositoryExtensions.updateTimestamp(
-            SCHEDULER_TYPE, Instant.now(), SECONDS);
+                SCHEDULER_TYPE, Instant.now(), SECONDS);
 
         assertThat(updated).isFalse();
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/mesh/token/MeshAuthorizationTokenTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/mesh/token/MeshAuthorizationTokenTest.java
@@ -38,7 +38,7 @@ class MeshAuthorizationTokenTest {
     @SuppressWarnings("checkstyle:magicnumber")
     void testTokenUsesCorrectFormat() {
         final MeshAuthorizationToken meshToken = new MeshAuthorizationToken(
-            meshConfig, FIXED_TIME_LOCAL, new Nonce(UUID), authorizationHashGenerator);
+                meshConfig, FIXED_TIME_LOCAL, new Nonce(UUID), authorizationHashGenerator);
         SoftAssertions.assertSoftly(softly -> {
             String[] values = meshToken.getValue().split(":");
             softly.assertThat(values[0]).isEqualTo("NHSMESH " + MAILBOX_ID);
@@ -47,8 +47,8 @@ class MeshAuthorizationTokenTest {
             softly.assertThat(values[3]).isEqualTo(new TokenTimestamp(FIXED_TIME_LOCAL).getValue());
             softly.assertThat(values[4]).isEqualTo(AUTHORIZATION_HASH);
             softly.assertThat(meshToken.getValue())
-                .isEqualTo("NHSMESH mailbox_id:73eefd69-811f-44d0-81f8-a54ff352a991:1:"
-                    + "199111061230:474c0634fd2267e41252bddfb40031d85e433599a8015c74546e95b05c2df569");
+                    .isEqualTo("NHSMESH mailbox_id:73eefd69-811f-44d0-81f8-a54ff352a991:1:"
+                            + "199111061230:474c0634fd2267e41252bddfb40031d85e433599a8015c74546e95b05c2df569");
         });
     }
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ClinicalInformationCodeTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ClinicalInformationCodeTest.java
@@ -14,8 +14,8 @@ class ClinicalInformationCodeTest {
         var edifactString = "CIN+";
 
         assertThatThrownBy(() -> ClinicalInformationCode.fromString(edifactString).validate())
-            .isInstanceOf(EdifactValidationException.class)
-            .hasMessage("CIN: Clinical Information Code is required");
+                .isInstanceOf(EdifactValidationException.class)
+                .hasMessage("CIN: Clinical Information Code is required");
     }
 
     @Test
@@ -23,18 +23,18 @@ class ClinicalInformationCodeTest {
         var edifactString = "CIN+UN";
 
         var clinicalInformationCode = ClinicalInformationCode.builder()
-            .code("UN")
-            .build();
+                .code("UN")
+                .build();
 
         assertThat(ClinicalInformationCode.fromString(edifactString))
-            .usingRecursiveComparison()
-            .isEqualTo(clinicalInformationCode);
+                .usingRecursiveComparison()
+                .isEqualTo(clinicalInformationCode);
     }
 
     @Test
     void testFromStringWithInvalidInput() {
         final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-            () -> ClinicalInformationCode.fromString("wrong value"));
+                () -> ClinicalInformationCode.fromString("wrong value"));
 
         assertEquals("Can't create ClinicalInformationCode from wrong value", exception.getMessage());
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DateFormatTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DateFormatTest.java
@@ -18,7 +18,7 @@ class DateFormatTest {
     @Test
     void testFromCodeForInvalidCodeThrowsException() {
         final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-            () -> DateFormat.fromCode("INVALID"));
+                () -> DateFormat.fromCode("INVALID"));
         assertEquals("No dateFormat name for 'INVALID'", exception.getMessage());
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DiagnosticReportCodeTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DiagnosticReportCodeTest.java
@@ -10,7 +10,7 @@ class DiagnosticReportCodeTest {
     @Test
     void testBuildWithNullCodeThrowsException() {
         final NullPointerException exception =
-            assertThrows(NullPointerException.class, () -> DiagnosticReportCode.builder().build());
+                assertThrows(NullPointerException.class, () -> DiagnosticReportCode.builder().build());
 
         assertEquals("code is marked non-null but is null", exception.getMessage());
     }
@@ -25,7 +25,7 @@ class DiagnosticReportCodeTest {
     @Test
     void testFromStringWithInvalidInput() {
         final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-            () -> DiagnosticReportCode.fromString("wrong value"));
+                () -> DiagnosticReportCode.fromString("wrong value"));
 
         assertEquals("Can't create DiagnosticReportCode from wrong value", exception.getMessage());
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DiagnosticReportDateIssuedTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DiagnosticReportDateIssuedTest.java
@@ -15,7 +15,7 @@ class DiagnosticReportDateIssuedTest {
     @Test
     void testBuildWithEmptyTimestampThrowsException() {
         final NullPointerException exception =
-            assertThrows(NullPointerException.class, () -> DiagnosticReportDateIssued.builder().build());
+                assertThrows(NullPointerException.class, () -> DiagnosticReportDateIssued.builder().build());
 
         assertEquals("dateIssued is marked non-null but is null", exception.getMessage());
     }
@@ -31,7 +31,8 @@ class DiagnosticReportDateIssuedTest {
     @Test
     void testFromStringWithInvalidEdifactStringThrowsException() {
         final IllegalArgumentException exception =
-            assertThrows(IllegalArgumentException.class, () -> DiagnosticReportDateIssued.fromString("wrong value"));
+                assertThrows(IllegalArgumentException.class,
+                        () -> DiagnosticReportDateIssued.fromString("wrong value"));
 
         assertEquals("Can't create DiagnosticReportDateIssued from wrong value", exception.getMessage());
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DiagnosticReportStatusTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/DiagnosticReportStatusTest.java
@@ -14,7 +14,7 @@ class DiagnosticReportStatusTest {
     @Test
     void testBuildWithNullEventThrowsException() {
         final NullPointerException exception =
-            assertThrows(NullPointerException.class, () -> DiagnosticReportStatus.builder().build());
+                assertThrows(NullPointerException.class, () -> DiagnosticReportStatus.builder().build());
 
         assertEquals("event is marked non-null but is null", exception.getMessage());
     }
@@ -24,16 +24,16 @@ class DiagnosticReportStatusTest {
         final DiagnosticReportStatus diagnosticReportStatus = DiagnosticReportStatus.fromString(VALID_EDIFACT);
 
         assertAll(
-            () -> assertEquals(KEY, diagnosticReportStatus.getKey()),
-            () -> assertEquals(ReportStatusCode.UNSPECIFIED, diagnosticReportStatus.getEvent()),
-            () -> assertEquals("Details", diagnosticReportStatus.getDetail())
+                () -> assertEquals(KEY, diagnosticReportStatus.getKey()),
+                () -> assertEquals(ReportStatusCode.UNSPECIFIED, diagnosticReportStatus.getEvent()),
+                () -> assertEquals("Details", diagnosticReportStatus.getDetail())
         );
     }
 
     @Test
     void testFromStringWithInvalidEdifactStringThrowsException() {
         final IllegalArgumentException exception =
-            assertThrows(IllegalArgumentException.class, () -> DiagnosticReportStatus.fromString("wrong value"));
+                assertThrows(IllegalArgumentException.class, () -> DiagnosticReportStatus.fromString("wrong value"));
 
         assertEquals("Can't create DiagnosticReportStatus from wrong value", exception.getMessage());
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/GenderTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/GenderTest.java
@@ -18,7 +18,7 @@ class GenderTest {
     @Test
     void testFromCodeForInvalidCodeThrowsException() {
         final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-            () -> Gender.fromCode("INVALID"));
+                () -> Gender.fromCode("INVALID"));
         assertEquals("No gender name for 'INVALID'", exception.getMessage());
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/GpNameAndAddressTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/GpNameAndAddressTest.java
@@ -19,16 +19,16 @@ class GpNameAndAddressTest {
     void testValidateEmptyIdentifier() {
         final GpNameAndAddress emptyIdentifier = new GpNameAndAddress("", "x");
         assertThatThrownBy(emptyIdentifier::validate)
-            .isExactlyInstanceOf(EdifactValidationException.class)
-            .hasMessage("NAD: Attribute identifier is required");
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("NAD: Attribute identifier is required");
     }
 
     @Test
     void testValidateEmptyCode() {
         final GpNameAndAddress emptyCode = new GpNameAndAddress("x", "");
         assertThatThrownBy(emptyCode::validate)
-            .isExactlyInstanceOf(EdifactValidationException.class)
-            .hasMessage("NAD: Attribute code is required");
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("NAD: Attribute code is required");
     }
 
     @Test
@@ -38,7 +38,7 @@ class GpNameAndAddressTest {
         assertThat(fromString.getIdentifier()).isEqualTo(gpNameAndAddress.getIdentifier());
         assertThat(fromString.getCode()).isEqualTo(gpNameAndAddress.getCode());
         assertThatThrownBy(() -> GpNameAndAddress.fromString("wrong value"))
-            .isExactlyInstanceOf(IllegalArgumentException.class);
+                .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/HealthAuthorityNameAndAddressTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/HealthAuthorityNameAndAddressTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class HealthAuthorityNameAndAddressTest {
     private final HealthAuthorityNameAndAddress healthAuthorityNameAndAddress
-        = new HealthAuthorityNameAndAddress("ABC", "code1");
+            = new HealthAuthorityNameAndAddress("ABC", "code1");
 
     @Test
     void testGetKey() {
@@ -19,16 +19,16 @@ class HealthAuthorityNameAndAddressTest {
     void testValidateEmptyIdentifier() {
         final var emptyIdentifier = new HealthAuthorityNameAndAddress("", "x");
         assertThatThrownBy(emptyIdentifier::validate)
-            .isExactlyInstanceOf(EdifactValidationException.class)
-            .hasMessage("NAD: Attribute identifier is required");
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("NAD: Attribute identifier is required");
     }
 
     @Test
     void testValidateEmptyCode() {
         final var emptyCode = new HealthAuthorityNameAndAddress("x", "");
         assertThatThrownBy(emptyCode::validate)
-            .isExactlyInstanceOf(EdifactValidationException.class)
-            .hasMessage("NAD: Attribute code is required");
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("NAD: Attribute code is required");
     }
 
     @Test
@@ -42,6 +42,6 @@ class HealthAuthorityNameAndAddressTest {
     @Test
     void testFromStringInvalidValue() {
         assertThatThrownBy(() -> HealthAuthorityNameAndAddress.fromString("wrong value"))
-            .isExactlyInstanceOf(IllegalArgumentException.class);
+                .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/InterchangeHeaderTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/InterchangeHeaderTest.java
@@ -12,10 +12,10 @@ class InterchangeHeaderTest {
     @Test
     void testValidateSequenceNumberNullThrowsException() {
         final InterchangeHeader interchangeHeader =
-            InterchangeHeader.fromString("UNB+UNOA:2+SNDR+RECP+190523:0900");
+                InterchangeHeader.fromString("UNB+UNOA:2+SNDR+RECP+190523:0900");
 
         final EdifactValidationException exception = assertThrows(EdifactValidationException.class,
-            interchangeHeader::validate);
+                interchangeHeader::validate);
 
         assertEquals("UNB: Attribute sequenceNumber is required", exception.getMessage());
     }
@@ -23,10 +23,10 @@ class InterchangeHeaderTest {
     @Test
     void testValidateSequenceNumberLessThanOneThrowsException() {
         final InterchangeHeader interchangeHeader =
-            InterchangeHeader.fromString("UNB+UNOA:2+SNDR+RECP+190523:0900+00000000");
+                InterchangeHeader.fromString("UNB+UNOA:2+SNDR+RECP+190523:0900+00000000");
 
         final EdifactValidationException exception = assertThrows(EdifactValidationException.class,
-            interchangeHeader::validate);
+                interchangeHeader::validate);
 
         assertEquals("UNB: Attribute sequenceNumber must be between 1 and 99999999", exception.getMessage());
     }
@@ -34,10 +34,10 @@ class InterchangeHeaderTest {
     @Test
     void testValidateSequenceNumberMoreThanMaxThrowsException() {
         final InterchangeHeader interchangeHeader =
-            InterchangeHeader.fromString("UNB+UNOA:2+SNDR+RECP+190523:0900+100000000");
+                InterchangeHeader.fromString("UNB+UNOA:2+SNDR+RECP+190523:0900+100000000");
 
         final EdifactValidationException exception = assertThrows(EdifactValidationException.class,
-            interchangeHeader::validate);
+                interchangeHeader::validate);
 
         assertEquals("UNB: Attribute sequenceNumber must be between 1 and 99999999", exception.getMessage());
     }
@@ -45,7 +45,7 @@ class InterchangeHeaderTest {
     @Test
     void testValidateSequenceNumberWithinMinMaxDoesNotThrowException() {
         final InterchangeHeader interchangeHeader =
-            InterchangeHeader.fromString("UNB+UNOA:2+SNDR+RECP+190523:0900+00000001");
+                InterchangeHeader.fromString("UNB+UNOA:2+SNDR+RECP+190523:0900+00000001");
 
         assertDoesNotThrow(interchangeHeader::validate);
     }
@@ -53,10 +53,10 @@ class InterchangeHeaderTest {
     @Test
     void testValidationEmptySenderThrowsException() {
         final InterchangeHeader interchangeHeader =
-            InterchangeHeader.fromString("UNB+UNOA:2++RECP+190523:0900+00000001");
+                InterchangeHeader.fromString("UNB+UNOA:2++RECP+190523:0900+00000001");
 
         final EdifactValidationException exception = assertThrows(EdifactValidationException.class,
-            interchangeHeader::validate);
+                interchangeHeader::validate);
 
         assertEquals("UNB: Attribute sender is required", exception.getMessage());
     }
@@ -64,10 +64,10 @@ class InterchangeHeaderTest {
     @Test
     void testValidationEmptyRecipientThrowsException() {
         final InterchangeHeader interchangeHeader =
-            InterchangeHeader.fromString("UNB+UNOA:2+SNDR++190523:0900+00000001");
+                InterchangeHeader.fromString("UNB+UNOA:2+SNDR++190523:0900+00000001");
 
         final EdifactValidationException exception = assertThrows(EdifactValidationException.class,
-            interchangeHeader::validate);
+                interchangeHeader::validate);
 
         assertEquals("UNB: Attribute recipient is required", exception.getMessage());
     }
@@ -85,7 +85,7 @@ class InterchangeHeaderTest {
     @Test
     void testFromStringWithInvalidEdifactStringThrowsException() {
         final IllegalArgumentException exception =
-            assertThrows(IllegalArgumentException.class, () -> InterchangeHeader.fromString("wrong value"));
+                assertThrows(IllegalArgumentException.class, () -> InterchangeHeader.fromString("wrong value"));
 
         assertEquals("Can't create InterchangeHeader from wrong value", exception.getMessage());
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/LaboratoryInvestigationResultTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/LaboratoryInvestigationResultTest.java
@@ -15,8 +15,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class LaboratoryInvestigationResultTest {
 
     private final LaboratoryInvestigationResult laboratoryInvestigationResult = new LaboratoryInvestigationResult(
-        new BigDecimal("11.9"), MeasurementValueComparator.LESS_THAN, "ng/mL",
-        DeviatingResultIndicator.ABOVE_HIGH_REFERENCE_LIMIT);
+            new BigDecimal("11.9"), MeasurementValueComparator.LESS_THAN, "ng/mL",
+            DeviatingResultIndicator.ABOVE_HIGH_REFERENCE_LIMIT);
 
     @Test
     void when_edifactStringDoesNotStartWithLaboratoryInvestigationResultKey_expect_illegalArgumentExceptionIsThrown() {
@@ -26,30 +26,30 @@ class LaboratoryInvestigationResultTest {
     @Test
     void when_edifactString1IsPassed_expect_returnALaboratoryInvestigationResultObject() {
         assertThat(laboratoryInvestigationResult)
-            .usingRecursiveComparison()
-            .isEqualTo(LaboratoryInvestigationResult.fromString("RSL+NV+11.9:7++:::ng/mL+HI"));
+                .usingRecursiveComparison()
+                .isEqualTo(LaboratoryInvestigationResult.fromString("RSL+NV+11.9:7++:::ng/mL+HI"));
     }
 
     @Test
     void when_edifactString2IsPassed_expect_returnALaboratoryInvestigationResultObject() {
         final LaboratoryInvestigationResult laboratoryInvestigationResult = new LaboratoryInvestigationResult(
-            new BigDecimal("11.9"), null, "ng/mL", DeviatingResultIndicator.ABOVE_HIGH_REFERENCE_LIMIT
+                new BigDecimal("11.9"), null, "ng/mL", DeviatingResultIndicator.ABOVE_HIGH_REFERENCE_LIMIT
         );
 
         assertThat(laboratoryInvestigationResult)
-            .usingRecursiveComparison()
-            .isEqualTo(LaboratoryInvestigationResult.fromString("RSL+NV+11.9++:::ng/mL+HI"));
+                .usingRecursiveComparison()
+                .isEqualTo(LaboratoryInvestigationResult.fromString("RSL+NV+11.9++:::ng/mL+HI"));
     }
 
     @Test
     void when_edifactString3IsPassed_expect_returnALaboratoryInvestigationResultObject() {
         final LaboratoryInvestigationResult laboratoryInvestigationResult = new LaboratoryInvestigationResult(
-            new BigDecimal("11.9"), null, "ng/mL", null
+                new BigDecimal("11.9"), null, "ng/mL", null
         );
 
         assertThat(laboratoryInvestigationResult)
-            .usingRecursiveComparison()
-            .isEqualTo(LaboratoryInvestigationResult.fromString("RSL+NV+11.9++:::ng/mL"));
+                .usingRecursiveComparison()
+                .isEqualTo(LaboratoryInvestigationResult.fromString("RSL+NV+11.9++:::ng/mL"));
     }
 
     @Test
@@ -67,17 +67,17 @@ class LaboratoryInvestigationResultTest {
         assertDoesNotThrow(laboratoryInvestigationResult::validate);
 
         LaboratoryInvestigationResult emptyMeasurementValue = new LaboratoryInvestigationResult(null,
-            MeasurementValueComparator.LESS_THAN, "ng/mL", DeviatingResultIndicator.ABOVE_HIGH_REFERENCE_LIMIT);
+                MeasurementValueComparator.LESS_THAN, "ng/mL", DeviatingResultIndicator.ABOVE_HIGH_REFERENCE_LIMIT);
         LaboratoryInvestigationResult emptyMeasurementUnit = new LaboratoryInvestigationResult(new BigDecimal("11.9"),
-            MeasurementValueComparator.LESS_THAN, null, DeviatingResultIndicator.ABOVE_HIGH_REFERENCE_LIMIT);
+                MeasurementValueComparator.LESS_THAN, null, DeviatingResultIndicator.ABOVE_HIGH_REFERENCE_LIMIT);
 
         assertAll(
-            () -> assertThatThrownBy(emptyMeasurementValue::validate)
-                .isExactlyInstanceOf(EdifactValidationException.class)
-                .hasMessage("RSL: Attribute measurementValue is required"),
-            () -> assertThatThrownBy(emptyMeasurementUnit::validate)
-                .isExactlyInstanceOf(EdifactValidationException.class)
-                .hasMessage("RSL: Attribute measurementUnit is required")
+                () -> assertThatThrownBy(emptyMeasurementValue::validate)
+                        .isExactlyInstanceOf(EdifactValidationException.class)
+                        .hasMessage("RSL: Attribute measurementValue is required"),
+                () -> assertThatThrownBy(emptyMeasurementUnit::validate)
+                        .isExactlyInstanceOf(EdifactValidationException.class)
+                        .hasMessage("RSL: Attribute measurementUnit is required")
         );
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/LaboratoryInvestigationTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/LaboratoryInvestigationTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class LaboratoryInvestigationTest {
 
     private final LaboratoryInvestigation laboratoryInvestigation = new LaboratoryInvestigation(
-        "42R4.", "Serum ferritin"
+            "42R4.", "Serum ferritin"
     );
 
     @Test
@@ -23,8 +23,8 @@ class LaboratoryInvestigationTest {
     @Test
     void when_edifactStringIsPassed_expect_returnALaboratoryInvestigationObject() {
         assertThat(laboratoryInvestigation)
-            .usingRecursiveComparison()
-            .isEqualTo(LaboratoryInvestigation.fromString("INV+MQ+42R4.:911::Serum ferritin"));
+                .usingRecursiveComparison()
+                .isEqualTo(LaboratoryInvestigation.fromString("INV+MQ+42R4.:911::Serum ferritin"));
     }
 
     @Test

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageRecipientNameAndAddressTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageRecipientNameAndAddressTest.java
@@ -12,40 +12,40 @@ class MessageRecipientNameAndAddressTest {
     @Test
     void testGetKey() {
         final var recipient = new MessageRecipientNameAndAddress("",
-            HealthcareRegistrationIdentificationCode.CONSULTANT, null);
+                HealthcareRegistrationIdentificationCode.CONSULTANT, null);
         assertThat(recipient.getKey()).isEqualTo("NAD");
     }
 
     @Test
     void testFromStringWrongKey() {
         assertThatThrownBy(() -> MessageRecipientNameAndAddress.fromString("WRONG+MR+ID:900++Name"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Can't create MessageRecipientNameAndAddress from WRONG+MR+ID:900++Name");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Can't create MessageRecipientNameAndAddress from WRONG+MR+ID:900++Name");
     }
 
     @Test
     void testFromStringAllValues() {
         final var recipient = MessageRecipientNameAndAddress.fromString("NAD+MR+ID:901++Aaron Aaronson");
         assertAll(
-            () -> assertThat(recipient.getIdentifier()).isEqualTo("ID"),
-            () -> assertThat(recipient.getHealthcareRegistrationIdentificationCode())
-                .isEqualTo(HealthcareRegistrationIdentificationCode.GP_PRACTICE),
-            () -> assertThat(recipient.getMessageRecipientName()).isEqualTo("Aaron Aaronson")
+                () -> assertThat(recipient.getIdentifier()).isEqualTo("ID"),
+                () -> assertThat(recipient.getHealthcareRegistrationIdentificationCode())
+                        .isEqualTo(HealthcareRegistrationIdentificationCode.GP_PRACTICE),
+                () -> assertThat(recipient.getMessageRecipientName()).isEqualTo("Aaron Aaronson")
         );
     }
 
     @Test
     void testFromStringUnknownHealthcareRegistrationIdentificationCode() {
         assertThatThrownBy(() -> MessageRecipientNameAndAddress.fromString("NAD+MR+123456:123++Mr Blobby"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("No HealthcareRegistrationIdentificationCode for '123'");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("No HealthcareRegistrationIdentificationCode for '123'");
     }
 
     @Test
     void testValidationPasses() {
         final var recipient = MessageRecipientNameAndAddress.fromString("NAD+MR+42:902++Woody Woodpecker");
         assertAll(
-            () -> assertDoesNotThrow(recipient::validate)
+                () -> assertDoesNotThrow(recipient::validate)
         );
     }
 
@@ -53,9 +53,9 @@ class MessageRecipientNameAndAddressTest {
     void testValidationBlankIdentifier() {
         final var recipient = MessageRecipientNameAndAddress.fromString("NAD+MR+:900++Wile E Coyote");
         assertAll(
-            () -> assertThatThrownBy(recipient::validate)
-                .isExactlyInstanceOf(EdifactValidationException.class)
-                .hasMessage("NAD: Attribute identifier is required")
+                () -> assertThatThrownBy(recipient::validate)
+                        .isExactlyInstanceOf(EdifactValidationException.class)
+                        .hasMessage("NAD: Attribute identifier is required")
         );
     }
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageTest.java
@@ -14,15 +14,15 @@ class MessageTest {
     @Test
     void testGetHealthAuthorityNameAndAddress() {
         final Message msg = new Message(List.of(
-            "NAD+FHS+XX1:954"
+                "NAD+FHS+XX1:954"
         ));
 
         HealthAuthorityNameAndAddress haAddress = msg.getHealthAuthorityNameAndAddress();
 
         assertAll(
-            () -> assertEquals("NAD", haAddress.getKey()),
-            () -> assertEquals("954", haAddress.getCode()),
-            () -> assertEquals("XX1", haAddress.getIdentifier())
+                () -> assertEquals("NAD", haAddress.getKey()),
+                () -> assertEquals("954", haAddress.getCode()),
+                () -> assertEquals("XX1", haAddress.getIdentifier())
         );
     }
 
@@ -38,8 +38,8 @@ class MessageTest {
     @Test
     void testFindFirstGpCodeReturnsCorrectly() {
         final Message msg = new Message(List.of(
-            "NAD+GP+2750922,295:900",
-            "NAD+GP+1649811,184:899"
+                "NAD+GP+2750922,295:900",
+                "NAD+GP+1649811,184:899"
         ));
 
         String firstGpCode = msg.findFirstGpCode();
@@ -50,38 +50,38 @@ class MessageTest {
     @Test
     void testGetInvolvedParties() {
         final var msg = new Message(List.of(
-            "ignore me",
-            "S01+01",
-            "party #1 contents",
-            "S01+01",
-            "party #2 contents",
-            "S02+02",
-            "ignore me"
+                "ignore me",
+                "S01+01",
+                "party #1 contents",
+                "S01+01",
+                "party #2 contents",
+                "S02+02",
+                "ignore me"
         ));
         assertAll(
-            () -> assertThat(msg.getInvolvedParties()).hasSize(2)
-                .first()
-                .extracting(InvolvedParty::getEdifactSegments)
-                .isEqualTo(List.of("S01+01", "party #1 contents")),
-            () -> assertThat(msg.getInvolvedParties())
-                .last()
-                .extracting(InvolvedParty::getEdifactSegments)
-                .isEqualTo(List.of("S01+01", "party #2 contents"))
+                () -> assertThat(msg.getInvolvedParties()).hasSize(2)
+                        .first()
+                        .extracting(InvolvedParty::getEdifactSegments)
+                        .isEqualTo(List.of("S01+01", "party #1 contents")),
+                () -> assertThat(msg.getInvolvedParties())
+                        .last()
+                        .extracting(InvolvedParty::getEdifactSegments)
+                        .isEqualTo(List.of("S01+01", "party #2 contents"))
         );
     }
 
     @Test
     void testGetServiceReportDetails() {
         final var msg = new Message(List.of(
-            "ignore me",
-            "S02+02",
-            "service report contents",
-            "UNT+18+00000003",
-            "ignore me"
+                "ignore me",
+                "S02+02",
+                "service report contents",
+                "UNT+18+00000003",
+                "ignore me"
         ));
         assertThat(msg.getServiceReportDetails())
-            .isNotNull()
-            .extracting(ServiceReportDetails::getEdifactSegments)
-            .isEqualTo(List.of("S02+02", "service report contents"));
+                .isNotNull()
+                .extracting(ServiceReportDetails::getEdifactSegments)
+                .isEqualTo(List.of("S02+02", "service report contents"));
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PerformerNameAndAddressTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PerformerNameAndAddressTest.java
@@ -1,17 +1,16 @@
 package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
 
+import org.junit.jupiter.api.Test;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.EdifactValidationException;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import org.junit.jupiter.api.Test;
-
-import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.EdifactValidationException;
 
 class PerformerNameAndAddressTest {
 
     private final PerformerNameAndAddress performingOrganisationNameAndAddress = PerformerNameAndAddress.builder()
-        .performingOrganisationName("LONDON CITY HOSPITAL")
-        .build();
+            .performingOrganisationName("LONDON CITY HOSPITAL")
+            .build();
 
     private final PerformerNameAndAddress performerNameAndAddress = PerformerNameAndAddress.builder()
             .identifier("A2442389")
@@ -22,34 +21,34 @@ class PerformerNameAndAddressTest {
     @Test
     void when_edifactStringDoesNotStartWithCorrectKey_expect_illegalArgumentExceptionIsThrown() {
         assertThatThrownBy(() -> PerformerNameAndAddress.fromString("wrong value"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Can't create PerformerNameAndAddress from wrong value");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Can't create PerformerNameAndAddress from wrong value");
     }
 
     @Test
     void when_edifactStringIsPassed_expect_returnAPerformingOrganisationNameAndAddressObject() {
         assertThat(performingOrganisationNameAndAddress)
-            .usingRecursiveComparison()
-            .isEqualTo(PerformerNameAndAddress.fromString("NAD+SLA+++LONDON CITY HOSPITAL"));
+                .usingRecursiveComparison()
+                .isEqualTo(PerformerNameAndAddress.fromString("NAD+SLA+++LONDON CITY HOSPITAL"));
     }
 
     @Test
     void when_edifactStringIsPassed_expect_returnAPerformerNameAndAddressObject() {
         assertThat(performerNameAndAddress)
-            .usingRecursiveComparison()
-            .isEqualTo(PerformerNameAndAddress.fromString("NAD+SLA+A2442389:902++DR J SMITH"));
+                .usingRecursiveComparison()
+                .isEqualTo(PerformerNameAndAddress.fromString("NAD+SLA+A2442389:902++DR J SMITH"));
     }
 
     @Test
     void when_buildingSegmentObjectWithEmptyHealthcareCode_expect_illegalArgumentExceptionIsThrown() {
         final var builder = PerformerNameAndAddress.builder()
-            .identifier("A2442389")
-            .performingOrganisationName("")
-            .performerName("");
+                .identifier("A2442389")
+                .performingOrganisationName("")
+                .performerName("");
 
         assertThatThrownBy(() -> builder.code(HealthcareRegistrationIdentificationCode.fromCode("")))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("No HealthcareRegistrationIdentificationCode for ''");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("No HealthcareRegistrationIdentificationCode for ''");
 
     }
 
@@ -61,7 +60,7 @@ class PerformerNameAndAddressTest {
     @Test
     void testGetPerformingOrganisationName() {
         assertThat(performingOrganisationNameAndAddress.getPerformingOrganisationName())
-            .isEqualTo("LONDON CITY HOSPITAL");
+                .isEqualTo("LONDON CITY HOSPITAL");
     }
 
     @Test
@@ -74,8 +73,8 @@ class PerformerNameAndAddressTest {
         var emptyPerformingOrganisationName = new PerformerNameAndAddress("", null, "", "");
 
         assertThatThrownBy(emptyPerformingOrganisationName::validate)
-            .isExactlyInstanceOf(EdifactValidationException.class)
-            .hasMessage("NAD: Attribute performingOrganisationName is required");
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("NAD: Attribute performingOrganisationName is required");
     }
 
     @Test
@@ -83,21 +82,21 @@ class PerformerNameAndAddressTest {
         var emptyCode = new PerformerNameAndAddress("Identifier", null, "", "DR J SMITH");
 
         assertThatThrownBy(emptyCode::validate)
-            .isExactlyInstanceOf(EdifactValidationException.class)
-            .hasMessage("NAD: Attribute code is required");
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("NAD: Attribute code is required");
     }
 
     @Test
     void testValidateMissingPerformerName() {
         var emptyPerformerName = new PerformerNameAndAddress(
-            "Identifier",
-            HealthcareRegistrationIdentificationCode.CONSULTANT,
-            null,
-            null
+                "Identifier",
+                HealthcareRegistrationIdentificationCode.CONSULTANT,
+                null,
+                null
         );
 
         assertThatThrownBy(emptyPerformerName::validate)
-            .isExactlyInstanceOf(EdifactValidationException.class)
-            .hasMessage("NAD: Attribute performerName is required");
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("NAD: Attribute performerName is required");
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonDateOfBirthTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonDateOfBirthTest.java
@@ -20,8 +20,8 @@ class PersonDateOfBirthTest {
         final PersonDateOfBirth personDateOfBirth = PersonDateOfBirth.fromString(VALID_EDIFACT_CCYY);
 
         assertAll("fromString date of birth format CCYY",
-            () -> assertEquals(PersonDateOfBirth.KEY, personDateOfBirth.getKey()),
-            () -> assertEquals(VALID_FHIR_DOB_CCYY, personDateOfBirth.getDateOfBirth()));
+                () -> assertEquals(PersonDateOfBirth.KEY, personDateOfBirth.getKey()),
+                () -> assertEquals(VALID_FHIR_DOB_CCYY, personDateOfBirth.getDateOfBirth()));
     }
 
     @Test
@@ -29,8 +29,8 @@ class PersonDateOfBirthTest {
         final PersonDateOfBirth personDateOfBirth = PersonDateOfBirth.fromString(VALID_EDIFACT_CCYYMM);
 
         assertAll("fromString date of birth format CCYYMM",
-            () -> assertEquals(PersonDateOfBirth.KEY, personDateOfBirth.getKey()),
-            () -> assertEquals(VALID_FHIR_DOB_CCYYMM, personDateOfBirth.getDateOfBirth()));
+                () -> assertEquals(PersonDateOfBirth.KEY, personDateOfBirth.getKey()),
+                () -> assertEquals(VALID_FHIR_DOB_CCYYMM, personDateOfBirth.getDateOfBirth()));
     }
 
     @Test
@@ -38,14 +38,14 @@ class PersonDateOfBirthTest {
         final PersonDateOfBirth personDateOfBirth = PersonDateOfBirth.fromString(VALID_EDIFACT_CCYYMMDD);
 
         assertAll("fromString date of birth format CCYYMMDD",
-            () -> assertEquals(PersonDateOfBirth.KEY, personDateOfBirth.getKey()),
-            () -> assertEquals(VALID_FHIR_DOB_CCYYMMDD, personDateOfBirth.getDateOfBirth()));
+                () -> assertEquals(PersonDateOfBirth.KEY, personDateOfBirth.getKey()),
+                () -> assertEquals(VALID_FHIR_DOB_CCYYMMDD, personDateOfBirth.getDateOfBirth()));
     }
 
     @Test
     void testFromStringWithInvalidEdifactStringThrowsException() {
         final IllegalArgumentException exception =
-            assertThrows(IllegalArgumentException.class, () -> PersonDateOfBirth.fromString("wrong value"));
+                assertThrows(IllegalArgumentException.class, () -> PersonDateOfBirth.fromString("wrong value"));
 
         assertEquals("Can't create PersonDateOfBirth from wrong value", exception.getMessage());
     }
@@ -53,7 +53,7 @@ class PersonDateOfBirthTest {
     @Test
     void testFromStringWithInvalidDateFormatCodeThrowsException() {
         final UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
-            () -> PersonDateOfBirth.fromString("DTM+329:19911106:100'"));
+                () -> PersonDateOfBirth.fromString("DTM+329:19911106:100'"));
 
         assertEquals("DTM: Date format code 100 is not supported", exception.getMessage());
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonIdentificationTypeTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonIdentificationTypeTest.java
@@ -18,7 +18,7 @@ class PersonIdentificationTypeTest {
     @Test
     void testFromCodeForInvalidCodeThrowsException() {
         final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-            () -> PatientIdentificationType.fromCode("INVALID"));
+                () -> PatientIdentificationType.fromCode("INVALID"));
         assertEquals("No patientIdentificationType name for 'INVALID'", exception.getMessage());
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonNameTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonNameTest.java
@@ -20,11 +20,11 @@ class PersonNameTest {
         var fromStringIdOnly = PersonName.fromString(ID_ONLY);
 
         assertAll("fromStringIdOnly",
-            () -> assertEquals(fromStringIdOnly.getNhsNumber(), "RAT56"),
-            () -> assertNull(fromStringIdOnly.getFirstForename()),
-            () -> assertNull(fromStringIdOnly.getSecondForename()),
-            () -> assertNull(fromStringIdOnly.getSurname()),
-            () -> assertNull(fromStringIdOnly.getTitle()));
+                () -> assertEquals(fromStringIdOnly.getNhsNumber(), "RAT56"),
+                () -> assertNull(fromStringIdOnly.getFirstForename()),
+                () -> assertNull(fromStringIdOnly.getSecondForename()),
+                () -> assertNull(fromStringIdOnly.getSurname()),
+                () -> assertNull(fromStringIdOnly.getTitle()));
     }
 
     @Test
@@ -32,11 +32,11 @@ class PersonNameTest {
         var fromStringIdAndNames = PersonName.fromString(ID_AND_NAMES_VALUE);
 
         assertAll("fromStringIdAndNames",
-            () -> assertEquals(fromStringIdAndNames.getNhsNumber(), "RAT56"),
-            () -> assertEquals(fromStringIdAndNames.getFirstForename(), "SARAH"),
-            () -> assertEquals(fromStringIdAndNames.getSecondForename(), "ANGELA"),
-            () -> assertEquals(fromStringIdAndNames.getSurname(), "KENNEDY"),
-            () -> assertEquals(fromStringIdAndNames.getTitle(), "MISS"));
+                () -> assertEquals(fromStringIdAndNames.getNhsNumber(), "RAT56"),
+                () -> assertEquals(fromStringIdAndNames.getFirstForename(), "SARAH"),
+                () -> assertEquals(fromStringIdAndNames.getSecondForename(), "ANGELA"),
+                () -> assertEquals(fromStringIdAndNames.getSurname(), "KENNEDY"),
+                () -> assertEquals(fromStringIdAndNames.getTitle(), "MISS"));
     }
 
     @Test
@@ -44,26 +44,26 @@ class PersonNameTest {
         var fromStringNamesOnly = PersonName.fromString(NAMES_ONLY_VALUE);
 
         assertAll("fromStringNamesOnly",
-            () -> assertNull(fromStringNamesOnly.getNhsNumber()),
-            () -> assertEquals(fromStringNamesOnly.getFirstForename(), "SARAH"),
-            () -> assertEquals(fromStringNamesOnly.getSecondForename(), "ANGELA"),
-            () -> assertEquals(fromStringNamesOnly.getSurname(), "KENNEDY"),
-            () -> assertEquals(fromStringNamesOnly.getTitle(), "MISS"));
+                () -> assertNull(fromStringNamesOnly.getNhsNumber()),
+                () -> assertEquals(fromStringNamesOnly.getFirstForename(), "SARAH"),
+                () -> assertEquals(fromStringNamesOnly.getSecondForename(), "ANGELA"),
+                () -> assertEquals(fromStringNamesOnly.getSurname(), "KENNEDY"),
+                () -> assertEquals(fromStringNamesOnly.getTitle(), "MISS"));
     }
 
     @Test
     void testFromStringWithInvalidEdifactStringThrowsException() {
         final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-            () -> PersonName.fromString("wrong value"));
+                () -> PersonName.fromString("wrong value"));
         assertEquals("Can't create PersonName from wrong value", exception.getMessage());
     }
 
     @Test
     void testFromStringWithBlankIdentificationAndBlankNamesThrowsException() {
         final EdifactValidationException exception = assertThrows(EdifactValidationException.class,
-            () -> PersonName.fromString("PNA+PAT+ +++ "));
+                () -> PersonName.fromString("PNA+PAT+ +++ "));
         assertEquals("PNA: At least one of patient identification and person name details are required",
-            exception.getMessage());
+                exception.getMessage());
     }
 
     @Test

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonSexTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/PersonSexTest.java
@@ -15,14 +15,14 @@ class PersonSexTest {
         final PersonSex personSex = PersonSex.fromString(VALID_EDIFACT);
 
         assertAll("fromString",
-            () -> assertEquals(PersonSex.KEY, personSex.getKey()),
-            () -> assertEquals(Gender.MALE, personSex.getGender()));
+                () -> assertEquals(PersonSex.KEY, personSex.getKey()),
+                () -> assertEquals(Gender.MALE, personSex.getGender()));
     }
 
     @Test
     void testFromStringWithInvalidEdifactStringThrowsException() {
         final IllegalArgumentException exception =
-            assertThrows(IllegalArgumentException.class, () -> PersonSex.fromString("wrong value"));
+                assertThrows(IllegalArgumentException.class, () -> PersonSex.fromString("wrong value"));
 
         assertEquals("Can't create PersonSex from wrong value", exception.getMessage());
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RangeDetailTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RangeDetailTest.java
@@ -19,19 +19,19 @@ class RangeDetailTest {
     @Test
     void testIncorrectHeader() {
         assertThatThrownBy(() -> RangeDetail.fromString("WRONG+U+0+10"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Can't create RangeDetail from WRONG+U+0+10");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Can't create RangeDetail from WRONG+U+0+10");
     }
 
     @Test
     void testMissingBothLimits() {
         var result = RangeDetail.fromString("RND+U++");
         assertAll(
-            () -> assertThat(result.getLowerLimit()).isNull(),
-            () -> assertThat(result.getUpperLimit()).isNull(),
-            () -> assertThatThrownBy(result::validate)
-                .isExactlyInstanceOf(EdifactValidationException.class)
-                .hasMessage("RND: At least one of lower reference limit and upper reference limit is required")
+                () -> assertThat(result.getLowerLimit()).isNull(),
+                () -> assertThat(result.getUpperLimit()).isNull(),
+                () -> assertThatThrownBy(result::validate)
+                        .isExactlyInstanceOf(EdifactValidationException.class)
+                        .hasMessage("RND: At least one of lower reference limit and upper reference limit is required")
         );
     }
 
@@ -39,9 +39,9 @@ class RangeDetailTest {
     void testOnlyLowerLimit() {
         var result = RangeDetail.fromString("RND+U+0+");
         assertAll(
-            () -> assertThat(result.getLowerLimit()).isEqualTo(BigDecimal.ZERO),
-            () -> assertThat(result.getUpperLimit()).isNull(),
-            () -> assertThatNoException().isThrownBy(result::validate)
+                () -> assertThat(result.getLowerLimit()).isEqualTo(BigDecimal.ZERO),
+                () -> assertThat(result.getUpperLimit()).isNull(),
+                () -> assertThatNoException().isThrownBy(result::validate)
         );
     }
 
@@ -49,9 +49,9 @@ class RangeDetailTest {
     void testOnlyUpperLimit() {
         var result = RangeDetail.fromString("RND+U++1");
         assertAll(
-            () -> assertThat(result.getLowerLimit()).isNull(),
-            () -> assertThat(result.getUpperLimit()).isEqualTo(BigDecimal.ONE),
-            () -> assertThatNoException().isThrownBy(result::validate)
+                () -> assertThat(result.getLowerLimit()).isNull(),
+                () -> assertThat(result.getUpperLimit()).isEqualTo(BigDecimal.ONE),
+                () -> assertThatNoException().isThrownBy(result::validate)
         );
     }
 
@@ -59,9 +59,9 @@ class RangeDetailTest {
     void testBothLimits() {
         var result = RangeDetail.fromString("RND+U+-1+1");
         assertAll(
-            () -> assertThat(result.getLowerLimit()).isEqualTo(BigDecimal.ONE.negate()),
-            () -> assertThat(result.getUpperLimit()).isEqualTo(BigDecimal.ONE),
-            () -> assertThatNoException().isThrownBy(result::validate)
+                () -> assertThat(result.getLowerLimit()).isEqualTo(BigDecimal.ONE.negate()),
+                () -> assertThat(result.getUpperLimit()).isEqualTo(BigDecimal.ONE),
+                () -> assertThatNoException().isThrownBy(result::validate)
         );
     }
 
@@ -70,9 +70,9 @@ class RangeDetailTest {
     void testRetainsPrecision() {
         var result = RangeDetail.fromString("RND+U+-1.0+1.00");
         assertAll(
-            () -> assertThat(result.getLowerLimit()).isEqualTo(BigDecimal.ONE.setScale(1).negate()),
-            () -> assertThat(result.getUpperLimit()).isEqualTo(BigDecimal.ONE.setScale(2)),
-            () -> assertThatNoException().isThrownBy(result::validate)
+                () -> assertThat(result.getLowerLimit()).isEqualTo(BigDecimal.ONE.setScale(1).negate()),
+                () -> assertThat(result.getUpperLimit()).isEqualTo(BigDecimal.ONE.setScale(2)),
+                () -> assertThatNoException().isThrownBy(result::validate)
         );
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ReferenceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ReferenceTest.java
@@ -19,23 +19,23 @@ class ReferenceTest {
     @Test
     void testFromStringWrongKey() {
         assertThatThrownBy(() -> Reference.fromString("WRONG+ARL:1A2B3C"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Can't create Reference from WRONG+ARL:1A2B3C");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Can't create Reference from WRONG+ARL:1A2B3C");
     }
 
     @Test
     void testFromStringUnrecognisedTarget() {
         assertThatThrownBy(() -> Reference.fromString("RFF+ZZZ:1A2B3C"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("No reference qualifier for 'ZZZ'");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("No reference qualifier for 'ZZZ'");
     }
 
     @Test
     void testFromStringAllValues() {
         final var reference = Reference.fromString("RFF+ASL:1A2B3C");
         assertAll(
-            () -> assertThat(reference.getTarget()).isEqualTo(ReferenceType.SPECIMEN),
-            () -> assertThat(reference.getNumber()).isEqualTo("1A2B3C")
+                () -> assertThat(reference.getTarget()).isEqualTo(ReferenceType.SPECIMEN),
+                () -> assertThat(reference.getNumber()).isEqualTo("1A2B3C")
         );
     }
 
@@ -43,7 +43,7 @@ class ReferenceTest {
     void testValidationPasses() {
         final var reference = new Reference(ReferenceType.SPECIMEN, "9");
         assertAll(
-            () -> assertDoesNotThrow(reference::validate)
+                () -> assertDoesNotThrow(reference::validate)
         );
     }
 
@@ -51,9 +51,9 @@ class ReferenceTest {
     void testValidationEmptyNumber() {
         final var reference = new Reference(ReferenceType.SPECIMEN, "");
         assertAll(
-            () -> assertThatThrownBy(reference::validate)
-                .isExactlyInstanceOf(EdifactValidationException.class)
-                .hasMessage("RFF: attribute number must be an alphanumeric string of up to 6 characters")
+                () -> assertThatThrownBy(reference::validate)
+                        .isExactlyInstanceOf(EdifactValidationException.class)
+                        .hasMessage("RFF: attribute number must be an alphanumeric string of up to 6 characters")
         );
     }
 
@@ -61,9 +61,9 @@ class ReferenceTest {
     void testValidationTooLongNumber() {
         final var reference = new Reference(ReferenceType.SPECIMEN, "Qwertyuiop");
         assertAll(
-            () -> assertThatThrownBy(reference::validate)
-                .isExactlyInstanceOf(EdifactValidationException.class)
-                .hasMessage("RFF: attribute number must be an alphanumeric string of up to 6 characters")
+                () -> assertThatThrownBy(reference::validate)
+                        .isExactlyInstanceOf(EdifactValidationException.class)
+                        .hasMessage("RFF: attribute number must be an alphanumeric string of up to 6 characters")
         );
     }
 
@@ -71,9 +71,9 @@ class ReferenceTest {
     void testValidationNonAlphanumericNumber() {
         final var reference = new Reference(ReferenceType.SPECIMEN, "失 🤯");
         assertAll(
-            () -> assertThatThrownBy(reference::validate)
-                .isExactlyInstanceOf(EdifactValidationException.class)
-                .hasMessage("RFF: attribute number must be an alphanumeric string of up to 6 characters")
+                () -> assertThatThrownBy(reference::validate)
+                        .isExactlyInstanceOf(EdifactValidationException.class)
+                        .hasMessage("RFF: attribute number must be an alphanumeric string of up to 6 characters")
         );
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ReportStatusCodeTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ReportStatusCodeTest.java
@@ -1,11 +1,11 @@
 package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ReportStatusCodeTest {
 
@@ -18,7 +18,7 @@ public class ReportStatusCodeTest {
     @Test
     void testFromCodeForInvalidCodeThrowsException() {
         final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-            () -> ReportStatusCode.fromCode("INVALID"));
+                () -> ReportStatusCode.fromCode("INVALID"));
 
         assertEquals("No Report Status Code for 'INVALID'", exception.getMessage());
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RequesterNameAndAddressTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/RequesterNameAndAddressTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class RequesterNameAndAddressTest {
 
     private final RequesterNameAndAddress requesterNameAndAddress = new RequesterNameAndAddress(
-        "ABC", HealthcareRegistrationIdentificationCode.GP, "SMITH"
+            "ABC", HealthcareRegistrationIdentificationCode.GP, "SMITH"
     );
 
     @Test
@@ -24,8 +24,8 @@ class RequesterNameAndAddressTest {
     @Test
     void when_edifactStringIsPassed_expect_returnARequesterNameAndAddressObject() {
         assertThat(requesterNameAndAddress)
-            .usingRecursiveComparison()
-            .isEqualTo(RequesterNameAndAddress.fromString("NAD+PO+ABC:900++SMITH"));
+                .usingRecursiveComparison()
+                .isEqualTo(RequesterNameAndAddress.fromString("NAD+PO+ABC:900++SMITH"));
     }
 
     @Test
@@ -33,26 +33,26 @@ class RequesterNameAndAddressTest {
         String edifactString = "NAD+PO+ABC:900++SMITH";
 
         RequesterNameAndAddress requester = RequesterNameAndAddress.builder()
-            .identifier("ABC")
-            .healthcareRegistrationIdentificationCode(HealthcareRegistrationIdentificationCode.GP)
-            .requesterName("SMITH")
-            .build();
+                .identifier("ABC")
+                .healthcareRegistrationIdentificationCode(HealthcareRegistrationIdentificationCode.GP)
+                .requesterName("SMITH")
+                .build();
 
         var fromString = RequesterNameAndAddress.fromString(edifactString);
 
         assertThat(fromString.getIdentifier()).isEqualTo("ABC");
         assertThat(fromString.getRequesterName()).isEqualTo("SMITH");
         assertThat(fromString.getHealthcareRegistrationIdentificationCode())
-            .isEqualTo(HealthcareRegistrationIdentificationCode.GP);
+                .isEqualTo(HealthcareRegistrationIdentificationCode.GP);
     }
 
     @Test
     void when_mappingSegmentObjectToEdifactStringWithEmptyIdentifierField_expect_edifactValidationException() {
         RequesterNameAndAddress requester = RequesterNameAndAddress.builder()
-            .identifier("")
-            .healthcareRegistrationIdentificationCode(HealthcareRegistrationIdentificationCode.GP)
-            .requesterName("SMITH")
-            .build();
+                .identifier("")
+                .healthcareRegistrationIdentificationCode(HealthcareRegistrationIdentificationCode.GP)
+                .requesterName("SMITH")
+                .build();
 
         assertThrows(EdifactValidationException.class, requester::validate);
     }
@@ -60,10 +60,10 @@ class RequesterNameAndAddressTest {
     @Test
     void when_mappingSegmentObjectToEdifactStringWithEmptyRequesterNameField_expect_edifactValidationException() {
         RequesterNameAndAddress requester = RequesterNameAndAddress.builder()
-            .identifier("ABC")
-            .healthcareRegistrationIdentificationCode(HealthcareRegistrationIdentificationCode.GP)
-            .requesterName("")
-            .build();
+                .identifier("ABC")
+                .healthcareRegistrationIdentificationCode(HealthcareRegistrationIdentificationCode.GP)
+                .requesterName("")
+                .build();
 
         assertThrows(EdifactValidationException.class, requester::validate);
     }
@@ -83,19 +83,19 @@ class RequesterNameAndAddressTest {
         assertDoesNotThrow(requesterNameAndAddress::validate);
 
         RequesterNameAndAddress emptyIdentifier = new RequesterNameAndAddress(
-            "", HealthcareRegistrationIdentificationCode.GP, "SMITH"
+                "", HealthcareRegistrationIdentificationCode.GP, "SMITH"
         );
         RequesterNameAndAddress emptyRequesterName = new RequesterNameAndAddress(
-            "ABC", HealthcareRegistrationIdentificationCode.GP, ""
+                "ABC", HealthcareRegistrationIdentificationCode.GP, ""
         );
 
         assertAll(
-            () -> assertThatThrownBy(emptyIdentifier::validate)
-                .isExactlyInstanceOf(EdifactValidationException.class)
-                .hasMessage("NAD: Attribute identifier is required"),
-            () -> assertThatThrownBy(emptyRequesterName::validate)
-                .isExactlyInstanceOf(EdifactValidationException.class)
-                .hasMessage("NAD: Attribute requesterName is required")
+                () -> assertThatThrownBy(emptyIdentifier::validate)
+                        .isExactlyInstanceOf(EdifactValidationException.class)
+                        .hasMessage("NAD: Attribute identifier is required"),
+                () -> assertThatThrownBy(emptyRequesterName::validate)
+                        .isExactlyInstanceOf(EdifactValidationException.class)
+                        .hasMessage("NAD: Attribute requesterName is required")
         );
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SequenceDetailsTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SequenceDetailsTest.java
@@ -18,8 +18,8 @@ class SequenceDetailsTest {
     @Test
     void testFromStringWrongKey() {
         assertThatThrownBy(() -> SequenceDetails.fromString("WRONG++123"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Can't create SequenceDetails from WRONG++123");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Can't create SequenceDetails from WRONG++123");
     }
 
     @Test
@@ -31,14 +31,14 @@ class SequenceDetailsTest {
     @Test
     void testFromStringInsufficientParts() {
         assertThatThrownBy(() -> SequenceDetails.fromString("SEQ+1"))
-            .isExactlyInstanceOf(ArrayIndexOutOfBoundsException.class);
+                .isExactlyInstanceOf(ArrayIndexOutOfBoundsException.class);
     }
 
     @Test
     void testValidationPasses() {
         final var sequence = new SequenceDetails("123456");
         assertAll(
-            () -> assertDoesNotThrow(sequence::validate)
+                () -> assertDoesNotThrow(sequence::validate)
         );
     }
 
@@ -46,9 +46,9 @@ class SequenceDetailsTest {
     void testValidationEmptyNumber() {
         final var sequence = new SequenceDetails("");
         assertAll(
-            () -> assertThatThrownBy(sequence::validate)
-                .isExactlyInstanceOf(EdifactValidationException.class)
-                .hasMessage("SEQ: attribute number must be an alphanumeric string of up to 6 characters")
+                () -> assertThatThrownBy(sequence::validate)
+                        .isExactlyInstanceOf(EdifactValidationException.class)
+                        .hasMessage("SEQ: attribute number must be an alphanumeric string of up to 6 characters")
         );
     }
 
@@ -56,9 +56,9 @@ class SequenceDetailsTest {
     void testValidationNonAlphaNumericNumber() {
         final var sequence = new SequenceDetails("1.00");
         assertAll(
-            () -> assertThatThrownBy(sequence::validate)
-                .isExactlyInstanceOf(EdifactValidationException.class)
-                .hasMessage("SEQ: attribute number must be an alphanumeric string of up to 6 characters")
+                () -> assertThatThrownBy(sequence::validate)
+                        .isExactlyInstanceOf(EdifactValidationException.class)
+                        .hasMessage("SEQ: attribute number must be an alphanumeric string of up to 6 characters")
         );
     }
 
@@ -66,9 +66,9 @@ class SequenceDetailsTest {
     void testValidationTooLongNumber() {
         final var sequence = new SequenceDetails("ABCDEFG");
         assertAll(
-            () -> assertThatThrownBy(sequence::validate)
-                .isExactlyInstanceOf(EdifactValidationException.class)
-                .hasMessage("SEQ: attribute number must be an alphanumeric string of up to 6 characters")
+                () -> assertThatThrownBy(sequence::validate)
+                        .isExactlyInstanceOf(EdifactValidationException.class)
+                        .hasMessage("SEQ: attribute number must be an alphanumeric string of up to 6 characters")
         );
 
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ServiceProviderTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/ServiceProviderTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class ServiceProviderTest {
 
     private final ServiceProvider serviceProvider = new ServiceProvider(
-        ServiceProviderCode.ORGANISATION
+            ServiceProviderCode.ORGANISATION
     );
 
     @Test
@@ -20,8 +20,8 @@ class ServiceProviderTest {
     @Test
     void when_edifactStringIsPassed_expect_returnAServiceProviderObject() {
         assertThat(serviceProvider)
-            .usingRecursiveComparison()
-            .isEqualTo(ServiceProvider.fromString("SPR+ORG"));
+                .usingRecursiveComparison()
+                .isEqualTo(ServiceProvider.fromString("SPR+ORG"));
     }
 
     @Test

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SpecimenCharacteristicTypeTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SpecimenCharacteristicTypeTest.java
@@ -18,22 +18,22 @@ class SpecimenCharacteristicTypeTest {
     @Test
     void testFromStringWithInvalidEdifactStringThrowsException() {
         assertThatThrownBy(() -> SpecimenCharacteristicType.fromString("wrong value"))
-            .isExactlyInstanceOf(IllegalArgumentException.class);
+                .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void testValidationEmptyString() {
         SpecimenCharacteristicType emptyFreeText = new SpecimenCharacteristicType(StringUtils.EMPTY);
         assertThatThrownBy(emptyFreeText::validate)
-            .isInstanceOf(EdifactValidationException.class)
-            .hasMessage("SPC: Attribute typeOfSpecimen is blank or missing");
+                .isInstanceOf(EdifactValidationException.class)
+                .hasMessage("SPC: Attribute typeOfSpecimen is blank or missing");
     }
 
     @Test
     void testValidationBlankString() {
         SpecimenCharacteristicType blankFreeText = new SpecimenCharacteristicType(" ");
         assertThatThrownBy(blankFreeText::validate)
-            .isInstanceOf(EdifactValidationException.class)
-            .hasMessage("SPC: Attribute typeOfSpecimen is blank or missing");
+                .isInstanceOf(EdifactValidationException.class)
+                .hasMessage("SPC: Attribute typeOfSpecimen is blank or missing");
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SpecimenCollectionDateTimeTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SpecimenCollectionDateTimeTest.java
@@ -14,9 +14,9 @@ class SpecimenCollectionDateTimeTest {
     @Test
     void testGetCollectionDateTimeForValidSpecimenCollectionDateTimeInFormatCCYYMMDD() {
         final var specimenCollectionDateTime = SpecimenCollectionDateTime.builder()
-            .collectionDateTime("20100223")
-            .dateFormat(DateFormat.CCYYMMDD)
-            .build();
+                .collectionDateTime("20100223")
+                .dateFormat(DateFormat.CCYYMMDD)
+                .build();
 
         final String actual = specimenCollectionDateTime.getCollectionDateTime();
 
@@ -26,9 +26,9 @@ class SpecimenCollectionDateTimeTest {
     @Test
     void testGetCollectionReceiptDateTimeForValidSpecimenCollectionDateTimeInFormatCCYYMMDDHHMM() {
         final var specimenCollectionDateTime = SpecimenCollectionDateTime.builder()
-            .collectionDateTime("201002231541")
-            .dateFormat(DateFormat.CCYYMMDDHHMM)
-            .build();
+                .collectionDateTime("201002231541")
+                .dateFormat(DateFormat.CCYYMMDDHHMM)
+                .build();
 
         final String actual = specimenCollectionDateTime.getCollectionDateTime();
 
@@ -38,36 +38,36 @@ class SpecimenCollectionDateTimeTest {
     @Test
     void testValidateForEmptySpecimenCollectionDateTimeThrowsException() {
         final var specimenCollectionDateTime = SpecimenCollectionDateTime.builder()
-            .collectionDateTime("")
-            .dateFormat(DateFormat.CCYYMMDD)
-            .build();
+                .collectionDateTime("")
+                .dateFormat(DateFormat.CCYYMMDD)
+                .build();
 
         assertThatThrownBy(specimenCollectionDateTime::validate)
-            .isExactlyInstanceOf(EdifactValidationException.class)
-            .hasMessage("DTM: Date/time of sample collection is required");
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("DTM: Date/time of sample collection is required");
     }
 
     @Test
     void testValidateForBlankSpecimenCollectionDateTimeThrowsException() {
         final var specimenCollectionDateTime = SpecimenCollectionDateTime.builder()
-            .collectionDateTime(" ")
-            .dateFormat(DateFormat.CCYYMMDD)
-            .build();
+                .collectionDateTime(" ")
+                .dateFormat(DateFormat.CCYYMMDD)
+                .build();
 
         assertThatThrownBy(specimenCollectionDateTime::validate)
-            .isExactlyInstanceOf(EdifactValidationException.class)
-            .hasMessage("DTM: Date/time of sample collection is required");
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("DTM: Date/time of sample collection is required");
     }
 
     @ParameterizedTest
     @CsvSource({"602,2021", "610,202101"})
     void testValidateUnsupportedDateFormatThrowsException(final String format, final String value) {
         final var specimenCollectionDateTime =
-            SpecimenCollectionDateTime.fromString("DTM+SCO:" + value + ":" + format);
+                SpecimenCollectionDateTime.fromString("DTM+SCO:" + value + ":" + format);
 
         assertThatThrownBy(specimenCollectionDateTime::validate)
-            .isExactlyInstanceOf(EdifactValidationException.class)
-            .hasMessage("DTM: Date format %s unsupported", format);
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("DTM: Date format %s unsupported", format);
     }
 
     @Test
@@ -75,8 +75,8 @@ class SpecimenCollectionDateTimeTest {
         final var specimenCollectionDateTime = SpecimenCollectionDateTime.fromString("DTM+SCO:20100223:102'");
 
         assertAll("fromString specimen collection date format CCYYMMDD",
-            () -> assertThat(specimenCollectionDateTime.getKey()).isEqualTo(SpecimenCollectionDateTime.KEY),
-            () -> assertThat(specimenCollectionDateTime.getCollectionDateTime()).isEqualTo("20100223"));
+                () -> assertThat(specimenCollectionDateTime.getKey()).isEqualTo(SpecimenCollectionDateTime.KEY),
+                () -> assertThat(specimenCollectionDateTime.getCollectionDateTime()).isEqualTo("20100223"));
     }
 
     @Test
@@ -84,30 +84,30 @@ class SpecimenCollectionDateTimeTest {
         final var specimenCollectionDateTime = SpecimenCollectionDateTime.fromString("DTM+SCO:201002231541:203'");
 
         assertAll("fromString specimen collection date format CCYYMMDDHHMM",
-            () -> assertThat(specimenCollectionDateTime.getKey()).isEqualTo(SpecimenCollectionDateTime.KEY),
-            () -> assertThat(specimenCollectionDateTime.getCollectionDateTime())
-                .isEqualTo("201002231541"));
+                () -> assertThat(specimenCollectionDateTime.getKey()).isEqualTo(SpecimenCollectionDateTime.KEY),
+                () -> assertThat(specimenCollectionDateTime.getCollectionDateTime())
+                        .isEqualTo("201002231541"));
     }
 
     @Test
     void testFromStringWithInvalidEdifactStringThrowsException() {
         assertThatThrownBy(() -> SpecimenCollectionDateTime.fromString("wrong value"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Can't create SpecimenCollectionDateTime from wrong value");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Can't create SpecimenCollectionDateTime from wrong value");
     }
 
     @Test
     void testFromStringWithInvalidDateFormatCodeThrowsException() {
         assertThatThrownBy(() -> SpecimenCollectionDateTime.fromString("DTM+SCO:20100223:100'"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("No dateFormat name for '100'");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("No dateFormat name for '100'");
     }
 
     @Test
     void testFromStringWithBlankDateFormatCodeThrowsException() {
         assertThatThrownBy(() -> SpecimenCollectionDateTime.fromString("DTM+SCO:20100223:'"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Can't create SpecimenCollectionDateTime from DTM+SCO:20100223:'"
-                + " because of missing date-time and/or format definition");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Can't create SpecimenCollectionDateTime from DTM+SCO:20100223:'"
+                        + " because of missing date-time and/or format definition");
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SpecimenCollectionReceiptDateTimeTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SpecimenCollectionReceiptDateTimeTest.java
@@ -14,9 +14,9 @@ class SpecimenCollectionReceiptDateTimeTest {
     @Test
     void testGetCollectionReceiptDateTimeForValidSpecimenCollectionReceiptDateTimeInFormatCCYYMMDD() {
         final var specimenCollectionReceiptDateTime = SpecimenCollectionReceiptDateTime.builder()
-            .collectionReceiptDateTime("20100223")
-            .dateFormat(DateFormat.CCYYMMDD)
-            .build();
+                .collectionReceiptDateTime("20100223")
+                .dateFormat(DateFormat.CCYYMMDD)
+                .build();
 
         final String actual = specimenCollectionReceiptDateTime.getCollectionReceiptDateTime();
 
@@ -26,9 +26,9 @@ class SpecimenCollectionReceiptDateTimeTest {
     @Test
     void testGetCollectionReceiptDateTimeForValidSpecimenCollectionReceiptDateTimeInFormatCCYYMMDDHHMM() {
         final var specimenCollectionReceiptDateTime = SpecimenCollectionReceiptDateTime.builder()
-            .collectionReceiptDateTime("201002231541")
-            .dateFormat(DateFormat.CCYYMMDDHHMM)
-            .build();
+                .collectionReceiptDateTime("201002231541")
+                .dateFormat(DateFormat.CCYYMMDDHHMM)
+                .build();
 
         final String actual = specimenCollectionReceiptDateTime.getCollectionReceiptDateTime();
 
@@ -38,79 +38,79 @@ class SpecimenCollectionReceiptDateTimeTest {
     @Test
     void testValidateForEmptySpecimenCollectionReceiptDateTimeThrowsException() {
         final var specimenCollectionReceiptDateTime = SpecimenCollectionReceiptDateTime.builder()
-            .collectionReceiptDateTime("")
-            .dateFormat(DateFormat.CCYYMMDD)
-            .build();
+                .collectionReceiptDateTime("")
+                .dateFormat(DateFormat.CCYYMMDD)
+                .build();
 
         assertThatThrownBy(specimenCollectionReceiptDateTime::validate)
-            .isExactlyInstanceOf(EdifactValidationException.class)
-            .hasMessage("DTM: Date/time of sample collection is required");
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("DTM: Date/time of sample collection is required");
     }
 
     @Test
     void testValidateForBlankSpecimenCollectionReceiptDateTimeThrowsException() {
         final var specimenCollectionReceiptDateTime = SpecimenCollectionReceiptDateTime.builder()
-            .collectionReceiptDateTime(" ")
-            .dateFormat(DateFormat.CCYYMMDD)
-            .build();
+                .collectionReceiptDateTime(" ")
+                .dateFormat(DateFormat.CCYYMMDD)
+                .build();
 
         assertThatThrownBy(specimenCollectionReceiptDateTime::validate)
-            .isExactlyInstanceOf(EdifactValidationException.class)
-            .hasMessage("DTM: Date/time of sample collection is required");
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("DTM: Date/time of sample collection is required");
     }
 
     @ParameterizedTest
     @CsvSource({"602,2021", "610,202101"})
     void testValidateUnsupportedDateFormatThrowsException(final String format, final String value) {
         final var specimenCollectionReceiptDateTime =
-            SpecimenCollectionReceiptDateTime.fromString("DTM+SRI:" + value + ":" + format);
+                SpecimenCollectionReceiptDateTime.fromString("DTM+SRI:" + value + ":" + format);
 
         assertThatThrownBy(specimenCollectionReceiptDateTime::validate)
-            .isExactlyInstanceOf(EdifactValidationException.class)
-            .hasMessage("DTM: Date format %s unsupported", format);
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("DTM: Date format %s unsupported", format);
     }
 
     @Test
     void testFromStringWithValidEdifactStringReturnsSpecimenCollectionReceiptDateTimeInFormatCCYYMMDD() {
         final SpecimenCollectionReceiptDateTime specimenCollectionReceiptDateTime =
-            SpecimenCollectionReceiptDateTime.fromString("DTM+SRI:20100223:102'");
+                SpecimenCollectionReceiptDateTime.fromString("DTM+SRI:20100223:102'");
 
         assertAll("fromString specimen collection date format CCYYMMDD",
-            () -> assertThat(specimenCollectionReceiptDateTime.getKey()).isEqualTo(SpecimenCollectionDateTime.KEY),
-            () -> assertThat(specimenCollectionReceiptDateTime.getCollectionReceiptDateTime())
-                .isEqualTo("20100223"));
+                () -> assertThat(specimenCollectionReceiptDateTime.getKey()).isEqualTo(SpecimenCollectionDateTime.KEY),
+                () -> assertThat(specimenCollectionReceiptDateTime.getCollectionReceiptDateTime())
+                        .isEqualTo("20100223"));
     }
 
     @Test
     void testFromStringWithValidEdifactStringReturnsSpecimenCollectionReceiptDateTimeInFormatCCYYMMDDHHMM() {
         final SpecimenCollectionReceiptDateTime specimenCollectionReceiptDateTime =
-            SpecimenCollectionReceiptDateTime.fromString("DTM+SRI:201002231541:203'");
+                SpecimenCollectionReceiptDateTime.fromString("DTM+SRI:201002231541:203'");
 
         assertAll("fromString specimen collection date format CCYYMMDDHHMM",
-            () -> assertThat(specimenCollectionReceiptDateTime.getKey()).isEqualTo(SpecimenCollectionDateTime.KEY),
-            () -> assertThat(specimenCollectionReceiptDateTime.getCollectionReceiptDateTime())
-                .isEqualTo("201002231541"));
+                () -> assertThat(specimenCollectionReceiptDateTime.getKey()).isEqualTo(SpecimenCollectionDateTime.KEY),
+                () -> assertThat(specimenCollectionReceiptDateTime.getCollectionReceiptDateTime())
+                        .isEqualTo("201002231541"));
     }
 
     @Test
     void testFromStringWithInvalidEdifactStringThrowsException() {
         assertThatThrownBy(() -> SpecimenCollectionReceiptDateTime.fromString("wrong value"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Can't create SpecimenCollectionReceiptDateTime from wrong value");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Can't create SpecimenCollectionReceiptDateTime from wrong value");
     }
 
     @Test
     void testFromStringWithInvalidDateFormatCodeThrowsException() {
         assertThatThrownBy(() -> SpecimenCollectionReceiptDateTime.fromString("DTM+SRI:20100223:100'"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("No dateFormat name for '100'");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("No dateFormat name for '100'");
     }
 
     @Test
     void testFromStringWithBlankDateFormatCodeThrowsException() {
         assertThatThrownBy(() -> SpecimenCollectionReceiptDateTime.fromString("DTM+SRI:20100223:'"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Can't create SpecimenCollectionReceiptDateTime from DTM+SRI:20100223:'"
-                + " because of missing date-time and/or format definition");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Can't create SpecimenCollectionReceiptDateTime from DTM+SRI:20100223:'"
+                        + " because of missing date-time and/or format definition");
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SpecimenQuantityTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/SpecimenQuantityTest.java
@@ -22,22 +22,22 @@ class SpecimenQuantityTest {
     @Test
     void testFromStringWithInvalidEdifactStringThrowsException() {
         assertThatThrownBy(() -> SpecimenQuantity.fromString("wrong value"))
-            .isExactlyInstanceOf(IllegalArgumentException.class);
+                .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void testValidationQuantityUnitOfMeasureEmptyString() {
         SpecimenQuantity emptyFreeText = new SpecimenQuantity(SPECIMEN_QUANTITY, StringUtils.EMPTY);
         assertThatThrownBy(emptyFreeText::validate)
-            .isInstanceOf(EdifactValidationException.class)
-            .hasMessage("QTY: Unit of measure is required");
+                .isInstanceOf(EdifactValidationException.class)
+                .hasMessage("QTY: Unit of measure is required");
     }
 
     @Test
     void testValidationQuantityUnitOfMeasureBlankString() {
         SpecimenQuantity emptyFreeText = new SpecimenQuantity(SPECIMEN_QUANTITY, " ");
         assertThatThrownBy(emptyFreeText::validate)
-            .isInstanceOf(EdifactValidationException.class)
-            .hasMessage("QTY: Unit of measure is required");
+                .isInstanceOf(EdifactValidationException.class)
+                .hasMessage("QTY: Unit of measure is required");
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/TestStatusTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/TestStatusTest.java
@@ -24,29 +24,29 @@ class TestStatusTest {
     @Test
     void when_edifactStringIsPassed_expect_returnATestStatusObject() {
         var valueMap = Map.of(
-            TestStatusCode.CORRECTED, "CO",
-            TestStatusCode.UNKNOWN, "UN",
-            TestStatusCode.AMENDED, "AM",
-            TestStatusCode.CANCELLED, "CA",
-            TestStatusCode.ENTERED_IN_ERROR, "EN",
-            TestStatusCode.FINAL, "FI",
-            TestStatusCode.PRELIMINARY, "PR",
-            TestStatusCode.REGISTERED, "RE");
+                TestStatusCode.CORRECTED, "CO",
+                TestStatusCode.UNKNOWN, "UN",
+                TestStatusCode.AMENDED, "AM",
+                TestStatusCode.CANCELLED, "CA",
+                TestStatusCode.ENTERED_IN_ERROR, "EN",
+                TestStatusCode.FINAL, "FI",
+                TestStatusCode.PRELIMINARY, "PR",
+                TestStatusCode.REGISTERED, "RE");
 
         assertThat(valueMap).hasSameSizeAs(TestStatusCode.values());
 
         for (TestStatusCode testStatusCode : TestStatusCode.values()) {
             assertThat(new TestStatus(testStatusCode)).usingRecursiveComparison()
-                .isEqualTo(TestStatus.fromString("STS++" + valueMap.get(testStatusCode)));
+                    .isEqualTo(TestStatus.fromString("STS++" + valueMap.get(testStatusCode)));
         }
 
         assertAll(
-            () -> assertThatThrownBy(() -> TestStatus.fromString("STS++XX"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("No test status code for 'XX'"),
-            () -> assertThatThrownBy(() -> TestStatus.fromString("STS++"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("No test status code for ''")
+                () -> assertThatThrownBy(() -> TestStatus.fromString("STS++XX"))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessage("No test status code for 'XX'"),
+                () -> assertThatThrownBy(() -> TestStatus.fromString("STS++"))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessage("No test status code for ''")
         );
     }
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/UnstructuredAddressTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/UnstructuredAddressTest.java
@@ -12,23 +12,24 @@ class UnstructuredAddressTest {
     @Test
     void testGetKey() {
         assertThat(new UnstructuredAddress(null, null, null).getKey())
-            .isEqualTo("ADR");
+                .isEqualTo("ADR");
     }
 
     @Test
     void testFromStringWrongPrefix() {
         assertThatThrownBy(() -> UnstructuredAddress.fromString("WRONG++BLAH:BLAH"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Can't create UnstructuredAddress from WRONG++BLAH:BLAH");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Can't create UnstructuredAddress from WRONG++BLAH:BLAH");
     }
 
     @Test
     void testFromStringValidWithAllFields() {
         final var address = UnstructuredAddress.fromString("ADR++US:LINE1:LINE2:LINE3:LINE4:LINE5++POSTCODE");
         assertAll(
-            () -> assertThat(address.getFormat()).isEqualTo("US"),
-            () -> assertThat(address.getAddressLines()).containsExactly("LINE1", "LINE2", "LINE3", "LINE4", "LINE5"),
-            () -> assertThat(address.getPostCode()).isEqualTo("POSTCODE")
+                () -> assertThat(address.getFormat()).isEqualTo("US"),
+                () -> assertThat(address.getAddressLines())
+                        .containsExactly("LINE1", "LINE2", "LINE3", "LINE4", "LINE5"),
+                () -> assertThat(address.getPostCode()).isEqualTo("POSTCODE")
         );
     }
 
@@ -36,9 +37,9 @@ class UnstructuredAddressTest {
     void testFromStringValidWithMinimumAddressFields() {
         final var address = UnstructuredAddress.fromString("ADR++US:LINE1::::++");
         assertAll(
-            () -> assertThat(address.getFormat()).isEqualTo("US"),
-            () -> assertThat(address.getAddressLines()).containsExactly("LINE1", "", "", "", ""),
-            () -> assertThat(address.getPostCode()).isEmpty()
+                () -> assertThat(address.getFormat()).isEqualTo("US"),
+                () -> assertThat(address.getAddressLines()).containsExactly("LINE1", "", "", "", ""),
+                () -> assertThat(address.getPostCode()).isEmpty()
         );
     }
 
@@ -46,9 +47,9 @@ class UnstructuredAddressTest {
     void testFromStringValidWithOnlyPostcode() {
         final var address = UnstructuredAddress.fromString("ADR++++POSTCODE");
         assertAll(
-            () -> assertThat(address.getFormat()).isEmpty(),
-            () -> assertThat(address.getAddressLines()).isNull(),
-            () -> assertThat(address.getPostCode()).isEqualTo("POSTCODE")
+                () -> assertThat(address.getFormat()).isEmpty(),
+                () -> assertThat(address.getAddressLines()).isNull(),
+                () -> assertThat(address.getPostCode()).isEqualTo("POSTCODE")
         );
     }
 
@@ -56,31 +57,31 @@ class UnstructuredAddressTest {
     void testValidateInvalidMissingAddressAndPostcode() {
         final var address = UnstructuredAddress.fromString("ADR++++");
         assertThatThrownBy(address::validate)
-            .isExactlyInstanceOf(EdifactValidationException.class)
-            .hasMessage("ADR: attribute addressLines is required when postcode is missing");
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("ADR: attribute addressLines is required when postcode is missing");
     }
 
     @Test
     void testValidateInvalidInsufficientAddressLines() {
         final var address = UnstructuredAddress.fromString("ADR++US++");
         assertThatThrownBy(address::validate)
-            .isExactlyInstanceOf(EdifactValidationException.class)
-            .hasMessage("ADR: attribute addressLines is required when postcode is missing");
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("ADR: attribute addressLines is required when postcode is missing");
     }
 
     @Test
     void testValidateInvalidMissingFormat() {
         final var address = UnstructuredAddress.fromString("ADR++:LINE1::::++");
         assertThatThrownBy(address::validate)
-            .isExactlyInstanceOf(EdifactValidationException.class)
-            .hasMessage("ADR: format of 'US' is required when postCode is missing");
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("ADR: format of 'US' is required when postCode is missing");
     }
 
     @Test
     void testValidateInvalidMissingPostcodeAndLine1() {
         final var address = UnstructuredAddress.fromString("ADR++US::LINE2:::++");
         assertThatThrownBy(address::validate)
-            .isExactlyInstanceOf(EdifactValidationException.class)
-            .hasMessage("ADR: attribute addressLines[0] is required");
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("ADR: attribute addressLines[0] is required");
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/InvestigationSubjectTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/InvestigationSubjectTest.java
@@ -19,116 +19,116 @@ class InvestigationSubjectTest {
     @Test
     void testGetReferenceServiceSubject() {
         final var investigationSubject = new InvestigationSubject(List.of(
-            "ignore me",
-            "RFF+SSI:X88442211",
-            "ignore me"
+                "ignore me",
+                "RFF+SSI:X88442211",
+                "ignore me"
         ));
         var referenceServiceSubject = assertThat(investigationSubject.getReferenceServiceSubject()).isPresent();
 
         referenceServiceSubject
-            .map(Reference::getNumber)
-            .hasValue("X88442211");
+                .map(Reference::getNumber)
+                .hasValue("X88442211");
         referenceServiceSubject
-            .map(Reference::getTarget)
-            .hasValue(ReferenceType.SERVICE_SUBJECT);
+                .map(Reference::getTarget)
+                .hasValue(ReferenceType.SERVICE_SUBJECT);
     }
 
     @Test
     void testGetUnstructuredAddress() {
         final var investigationSubject = new InvestigationSubject(List.of(
-            "ignore me",
-            "ADR++US:FLAT1:12 BROWNBERRIE AVENUE::LEEDS:++LS18 5PN",
-            "ignore me"
+                "ignore me",
+                "ADR++US:FLAT1:12 BROWNBERRIE AVENUE::LEEDS:++LS18 5PN",
+                "ignore me"
         ));
         var investigationSubjectAddress = assertThat(investigationSubject.getAddress()).isPresent();
 
         investigationSubjectAddress
-            .map(UnstructuredAddress::getAddressLines)
-            .contains(new String[] {"FLAT1", "12 BROWNBERRIE AVENUE", "", "LEEDS", ""});
+                .map(UnstructuredAddress::getAddressLines)
+                .contains(new String[]{"FLAT1", "12 BROWNBERRIE AVENUE", "", "LEEDS", ""});
 
         investigationSubjectAddress
-            .map(UnstructuredAddress::getFormat)
-            .hasValue("US");
+                .map(UnstructuredAddress::getFormat)
+                .hasValue("US");
         investigationSubjectAddress
-            .map(UnstructuredAddress::getPostCode)
-            .hasValue("LS18 5PN");
+                .map(UnstructuredAddress::getPostCode)
+                .hasValue("LS18 5PN");
     }
 
     @Test
     void testGetPatientDetails() {
         final var investigationSubject = new InvestigationSubject(List.of(
-            "ignore me",
-            "S07+07",
-            "include me",
-            "S16+16",
-            "ignore me"
+                "ignore me",
+                "S07+07",
+                "include me",
+                "S16+16",
+                "ignore me"
         ));
         assertThat(investigationSubject.getDetails())
-            .isNotNull()
-            .extracting(PatientDetails::getEdifactSegments)
-            .isEqualTo(List.of("S07+07", "include me"));
+                .isNotNull()
+                .extracting(PatientDetails::getEdifactSegments)
+                .isEqualTo(List.of("S07+07", "include me"));
     }
 
     @Test
     void testGetPatientClinicalInfo() {
         final var investigationSubject = new InvestigationSubject(List.of(
-            "ignore me",
-            "S10+10",
-            "include me",
-            "S16+16",
-            "ignore me"
+                "ignore me",
+                "S10+10",
+                "include me",
+                "S16+16",
+                "ignore me"
         ));
         assertThat(investigationSubject.getClinicalInfo())
-            .isPresent()
-            .map(PatientClinicalInfo::getEdifactSegments)
-            .contains(List.of("S10+10", "include me"));
+                .isPresent()
+                .map(PatientClinicalInfo::getEdifactSegments)
+                .contains(List.of("S10+10", "include me"));
     }
 
     @Test
     void testGetSpecimens() {
         final var investigationSubject = new InvestigationSubject(List.of(
-            "ignore me",
-            "S16+16",
-            "specimen #1 contents",
-            "S16+16",
-            "specimen #2 contents",
-            "GIS+N",
-            "ignore me"
+                "ignore me",
+                "S16+16",
+                "specimen #1 contents",
+                "S16+16",
+                "specimen #2 contents",
+                "GIS+N",
+                "ignore me"
         ));
         assertAll(
-            () -> assertThat(investigationSubject.getSpecimens()).hasSize(2)
-                .first()
-                .extracting(SpecimenDetails::getEdifactSegments)
-                .isEqualTo(List.of("S16+16", "specimen #1 contents")),
-            () -> assertThat(investigationSubject.getSpecimens())
-                .last()
-                .extracting(SpecimenDetails::getEdifactSegments)
-                .isEqualTo(List.of("S16+16", "specimen #2 contents"))
+                () -> assertThat(investigationSubject.getSpecimens()).hasSize(2)
+                        .first()
+                        .extracting(SpecimenDetails::getEdifactSegments)
+                        .isEqualTo(List.of("S16+16", "specimen #1 contents")),
+                () -> assertThat(investigationSubject.getSpecimens())
+                        .last()
+                        .extracting(SpecimenDetails::getEdifactSegments)
+                        .isEqualTo(List.of("S16+16", "specimen #2 contents"))
         );
     }
 
     @Test
     void testGetLabResults() {
         final var investigationSubject = new InvestigationSubject(List.of(
-            "ignore me",
-            "GIS+N",
-            "result #1 contents",
-            "S20+20",
-            "result #1 range contents",
-            "GIS+N",
-            "result #2 contents",
-            "UNT+18+00000003",
-            "ignore me"
+                "ignore me",
+                "GIS+N",
+                "result #1 contents",
+                "S20+20",
+                "result #1 range contents",
+                "GIS+N",
+                "result #2 contents",
+                "UNT+18+00000003",
+                "ignore me"
         ));
         assertAll(
-            () -> assertThat(investigationSubject.getLabResults()).hasSize(2)
-                .first()
-                .extracting(LabResult::getEdifactSegments)
-                .isEqualTo(List.of("GIS+N", "result #1 contents", "S20+20", "result #1 range contents")),
-            () -> assertThat(investigationSubject.getLabResults())
-                .last()
-                .extracting(LabResult::getEdifactSegments)
-                .isEqualTo(List.of("GIS+N", "result #2 contents"))
+                () -> assertThat(investigationSubject.getLabResults()).hasSize(2)
+                        .first()
+                        .extracting(LabResult::getEdifactSegments)
+                        .isEqualTo(List.of("GIS+N", "result #1 contents", "S20+20", "result #1 range contents")),
+                () -> assertThat(investigationSubject.getLabResults())
+                        .last()
+                        .extracting(LabResult::getEdifactSegments)
+                        .isEqualTo(List.of("GIS+N", "result #2 contents"))
         );
     }
 
@@ -136,14 +136,14 @@ class InvestigationSubjectTest {
     void testLazyGettersWhenMissing() {
         final var investigationSubject = new InvestigationSubject(List.of());
         assertAll(
-            () -> assertThat(investigationSubject.getReferenceServiceSubject()).isEmpty(),
-            () -> assertThat(investigationSubject.getAddress()).isEmpty(),
-            () -> assertThat(investigationSubject.getDetails()).isNotNull()
-                .extracting(PatientDetails::getEdifactSegments)
-                .isEqualTo(List.of()),
-            () -> assertThat(investigationSubject.getClinicalInfo()).isEmpty(),
-            () -> assertThat(investigationSubject.getSpecimens()).isEmpty(),
-            () -> assertThat(investigationSubject.getLabResults()).isEmpty()
+                () -> assertThat(investigationSubject.getReferenceServiceSubject()).isEmpty(),
+                () -> assertThat(investigationSubject.getAddress()).isEmpty(),
+                () -> assertThat(investigationSubject.getDetails()).isNotNull()
+                        .extracting(PatientDetails::getEdifactSegments)
+                        .isEqualTo(List.of()),
+                () -> assertThat(investigationSubject.getClinicalInfo()).isEmpty(),
+                () -> assertThat(investigationSubject.getSpecimens()).isEmpty(),
+                () -> assertThat(investigationSubject.getLabResults()).isEmpty()
         );
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/InvolvedPartyTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/InvolvedPartyTest.java
@@ -22,87 +22,87 @@ class InvolvedPartyTest {
     @Test
     void testGetPerformingOrganisationNameAndAddress() {
         final var involvedParty = new InvolvedParty(List.of(
-            "ignore me",
-            "NAD+SLA+++ST JAMES?'S UNIVERSITY HOSPITAL",
-            "ignore me"
+                "ignore me",
+                "NAD+SLA+++ST JAMES?'S UNIVERSITY HOSPITAL",
+                "ignore me"
         ));
         assertThat(involvedParty.getPerformerNameAndAddress())
-            .isPresent()
-            .map(PerformerNameAndAddress::getPerformingOrganisationName)
-            .contains("ST JAMES?'S UNIVERSITY HOSPITAL");
+                .isPresent()
+                .map(PerformerNameAndAddress::getPerformingOrganisationName)
+                .contains("ST JAMES?'S UNIVERSITY HOSPITAL");
     }
 
     @Test
     void testGetRequesterNameAndAddress() {
         final var involvedParty = new InvolvedParty(List.of(
-            "ignore me",
-            "NAD+PO+G3380314:900++SCOTT",
-            "ignore me"
+                "ignore me",
+                "NAD+PO+G3380314:900++SCOTT",
+                "ignore me"
         ));
         var requesterNameAndAddress = involvedParty.getRequesterNameAndAddress();
         assertThat(requesterNameAndAddress)
-            .isPresent()
-            .map(RequesterNameAndAddress::getRequesterName)
-            .hasValue("SCOTT");
+                .isPresent()
+                .map(RequesterNameAndAddress::getRequesterName)
+                .hasValue("SCOTT");
         assertThat(requesterNameAndAddress)
-            .isPresent()
-            .map(RequesterNameAndAddress::getHealthcareRegistrationIdentificationCode)
-            .hasValue(HealthcareRegistrationIdentificationCode.GP);
+                .isPresent()
+                .map(RequesterNameAndAddress::getHealthcareRegistrationIdentificationCode)
+                .hasValue(HealthcareRegistrationIdentificationCode.GP);
         assertThat(requesterNameAndAddress)
-            .isPresent()
-            .map(RequesterNameAndAddress::getIdentifier)
-            .hasValue("G3380314");
+                .isPresent()
+                .map(RequesterNameAndAddress::getIdentifier)
+                .hasValue("G3380314");
     }
 
     @Test
     void testGetMessageRecipientNameAndAddress() {
         final var involvedParty = new InvolvedParty(List.of(
-            "ignore me",
-            "NAD+MR+G3380314:900++SCOTT",
-            "ignore me"
+                "ignore me",
+                "NAD+MR+G3380314:900++SCOTT",
+                "ignore me"
         ));
         var recipientNameAndAddress = involvedParty.getRecipientNameAndAddress();
         assertThat(recipientNameAndAddress)
-            .isPresent()
-            .map(MessageRecipientNameAndAddress::getMessageRecipientName)
-            .hasValue("SCOTT");
+                .isPresent()
+                .map(MessageRecipientNameAndAddress::getMessageRecipientName)
+                .hasValue("SCOTT");
         assertThat(recipientNameAndAddress)
-            .isPresent()
-            .map(MessageRecipientNameAndAddress::getHealthcareRegistrationIdentificationCode)
-            .hasValue(HealthcareRegistrationIdentificationCode.GP);
+                .isPresent()
+                .map(MessageRecipientNameAndAddress::getHealthcareRegistrationIdentificationCode)
+                .hasValue(HealthcareRegistrationIdentificationCode.GP);
         assertThat(recipientNameAndAddress)
-            .isPresent()
-            .map(MessageRecipientNameAndAddress::getIdentifier)
-            .hasValue("G3380314");
+                .isPresent()
+                .map(MessageRecipientNameAndAddress::getIdentifier)
+                .hasValue("G3380314");
     }
 
     @Test
     void testGetPartnerAgreedIdentification() {
         final var involvedParty = new InvolvedParty(List.of(
-            "ignore me",
-            "RFF+AHI:agreed ID",
-            "ignore me"
+                "ignore me",
+                "RFF+AHI:agreed ID",
+                "ignore me"
         ));
         var partnerAgreedId = involvedParty.getPartnerAgreedId();
         assertThat(partnerAgreedId)
-            .isPresent()
-            .map(Reference::getTarget)
-            .map(ReferenceType::getQualifier)
-            .contains("AHI");
+                .isPresent()
+                .map(Reference::getTarget)
+                .map(ReferenceType::getQualifier)
+                .contains("AHI");
         assertThat(partnerAgreedId)
-            .isPresent()
-            .map(Reference::getNumber)
-            .contains("agreed ID");
+                .isPresent()
+                .map(Reference::getNumber)
+                .contains("agreed ID");
     }
 
     @Test
     void testGetServiceProvider() {
         final var involvedParty = new InvolvedParty(List.of(
-            "ignore me",
-            "SPR+ORG",
-            "ignore me"
+                "ignore me",
+                "SPR+ORG",
+                "ignore me"
         ));
         assertThat(involvedParty.getServiceProvider().getServiceProviderCode())
-            .isEqualTo(ServiceProviderCode.ORGANISATION);
+                .isEqualTo(ServiceProviderCode.ORGANISATION);
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/LabResultTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/LabResultTest.java
@@ -34,183 +34,183 @@ class LabResultTest {
     @Test
     void testGetDiagnosticReportCode() {
         final var labResult = new LabResult(List.of(
-            "ignore me",
-            "GIS+N",
-            "ignore me"
+                "ignore me",
+                "GIS+N",
+                "ignore me"
         ));
         assertThat(labResult.getReportCode())
-            .isNotNull()
-            .extracting(DiagnosticReportCode::getCode)
-            .isEqualTo("N");
+                .isNotNull()
+                .extracting(DiagnosticReportCode::getCode)
+                .isEqualTo("N");
     }
 
     @Test
     void testGetLaboratoryInvestigation() {
         final var labResult = new LabResult(List.of(
-            "ignore me",
-            "INV+MQ+42R4.:911::Serum ferritin",
-            "ignore me"
+                "ignore me",
+                "INV+MQ+42R4.:911::Serum ferritin",
+                "ignore me"
         ));
         var labResultInvestigation = assertThat(labResult.getInvestigation()).isNotNull();
 
         labResultInvestigation
-            .extracting(LaboratoryInvestigation::getInvestigationCode)
-            .isEqualTo("42R4.");
+                .extracting(LaboratoryInvestigation::getInvestigationCode)
+                .isEqualTo("42R4.");
         labResultInvestigation
-            .extracting(LaboratoryInvestigation::getInvestigationDescription)
-            .isEqualTo("Serum ferritin");
+                .extracting(LaboratoryInvestigation::getInvestigationDescription)
+                .isEqualTo("Serum ferritin");
     }
 
     @Test
     void testGetSequenceDetails() {
         final var labResult = new LabResult(List.of(
-            "ignore me",
-            "SEQ++ABC123",
-            "ignore me"
+                "ignore me",
+                "SEQ++ABC123",
+                "ignore me"
         ));
         assertThat(labResult.getSequenceDetails())
-            .isPresent()
-            .map(SequenceDetails::getNumber)
-            .contains("ABC123");
+                .isPresent()
+                .map(SequenceDetails::getNumber)
+                .contains("ABC123");
     }
 
     @Test
     void testGetLaboratoryInvestigationResult() {
         final var labResult = new LabResult(List.of(
-            "ignore me",
-            "RSL+NV+11.9:7++:::ng/mL+HI",
-            "ignore me"
+                "ignore me",
+                "RSL+NV+11.9:7++:::ng/mL+HI",
+                "ignore me"
         ));
         var labResultInvestigationResult = assertThat(labResult.getInvestigationResult()).isPresent();
 
         labResultInvestigationResult
-            .map(LaboratoryInvestigationResult::getDeviatingResultIndicator)
-            .hasValue(DeviatingResultIndicator.ABOVE_HIGH_REFERENCE_LIMIT);
+                .map(LaboratoryInvestigationResult::getDeviatingResultIndicator)
+                .hasValue(DeviatingResultIndicator.ABOVE_HIGH_REFERENCE_LIMIT);
         labResultInvestigationResult
-            .map(LaboratoryInvestigationResult::getMeasurementUnit)
-            .hasValue("ng/mL");
+                .map(LaboratoryInvestigationResult::getMeasurementUnit)
+                .hasValue("ng/mL");
         labResultInvestigationResult
-            .map(LaboratoryInvestigationResult::getMeasurementValue)
-            .hasValue(BigDecimal.valueOf(EXPECTED_MEASUREMENT_VALUE));
+                .map(LaboratoryInvestigationResult::getMeasurementValue)
+                .hasValue(BigDecimal.valueOf(EXPECTED_MEASUREMENT_VALUE));
         labResultInvestigationResult
-            .map(LaboratoryInvestigationResult::getMeasurementValueComparator)
-            .hasValue(MeasurementValueComparator.LESS_THAN);
+                .map(LaboratoryInvestigationResult::getMeasurementValueComparator)
+                .hasValue(MeasurementValueComparator.LESS_THAN);
     }
 
     @Test
     void testGetTestStatus() {
         final var labResult = new LabResult(List.of(
-            "ignore me",
-            "STS++CO",
-            "ignore me"
+                "ignore me",
+                "STS++CO",
+                "ignore me"
         ));
         assertThat(labResult.getTestStatus())
-            .isPresent()
-            .map(TestStatus::getTestStatusCode)
-            .contains(TestStatusCode.CORRECTED);
+                .isPresent()
+                .map(TestStatus::getTestStatusCode)
+                .contains(TestStatusCode.CORRECTED);
     }
 
     @Test
     void testGetServiceProviderCommentFreeTexts() {
         final var labResult = new LabResult(List.of(
-            "ignore me",
-            "FTX+SPC+++red blood cell seen",
-            "ignore me",
-            "FTX+SPC+++Note low platelets",
-            "ignore me"
+                "ignore me",
+                "FTX+SPC+++red blood cell seen",
+                "ignore me",
+                "FTX+SPC+++Note low platelets",
+                "ignore me"
         ));
         var labResultFreeTexts = assertThat(labResult.getFreeTexts()).hasSize(2);
 
         labResultFreeTexts
-            .map(FreeTextSegment::getType)
-            .isEqualTo(List.of(FreeTextType.SERVICE_PROVIDER_COMMENT, FreeTextType.SERVICE_PROVIDER_COMMENT));
+                .map(FreeTextSegment::getType)
+                .isEqualTo(List.of(FreeTextType.SERVICE_PROVIDER_COMMENT, FreeTextType.SERVICE_PROVIDER_COMMENT));
         labResultFreeTexts
-            .map(FreeTextSegment::getTexts)
-            .map(values -> values[0])
-            .isEqualTo(List.of("red blood cell seen", "Note low platelets"));
+                .map(FreeTextSegment::getTexts)
+                .map(values -> values[0])
+                .isEqualTo(List.of("red blood cell seen", "Note low platelets"));
     }
 
     @Test
     void testGetInvestigationResultFreeTexts() {
         final var labResult = new LabResult(List.of(
-            "ignore me",
-            "FTX+RIT+++URINARY STONE weight 13 mg.",
-            "ignore me",
-            "FTX+RIT+++Consisted of 36% Calcium oxalate and 64% Calcium phosphate.",
-            "ignore me"
+                "ignore me",
+                "FTX+RIT+++URINARY STONE weight 13 mg.",
+                "ignore me",
+                "FTX+RIT+++Consisted of 36% Calcium oxalate and 64% Calcium phosphate.",
+                "ignore me"
         ));
 
         var labResultFreeTexts = assertThat(labResult.getFreeTexts()).hasSize(2);
 
         labResultFreeTexts
-            .map(FreeTextSegment::getType)
-            .isEqualTo(List.of(FreeTextType.INVESTIGATION_RESULT, FreeTextType.INVESTIGATION_RESULT));
+                .map(FreeTextSegment::getType)
+                .isEqualTo(List.of(FreeTextType.INVESTIGATION_RESULT, FreeTextType.INVESTIGATION_RESULT));
         labResultFreeTexts
-            .map(FreeTextSegment::getTexts)
-            .map(values -> values[0])
-            .isEqualTo(List.of(
-                "URINARY STONE weight 13 mg.", "Consisted of 36% Calcium oxalate and 64% Calcium phosphate."));
+                .map(FreeTextSegment::getTexts)
+                .map(values -> values[0])
+                .isEqualTo(List.of(
+                        "URINARY STONE weight 13 mg.", "Consisted of 36% Calcium oxalate and 64% Calcium phosphate."));
     }
 
     @Test
     void testGetComplexReferenceRangeFreeTexts() {
         final var labResult = new LabResult(List.of(
-            "ignore me",
-            "FTX+CRR+++DVT Prophylaxis - INR 2.0-2.5",
-            "ignore me",
-            "FTX+CRR+++Treatment of DVT,PE,AF,TIA - INR 2.0-3.0",
-            "ignore me"
+                "ignore me",
+                "FTX+CRR+++DVT Prophylaxis - INR 2.0-2.5",
+                "ignore me",
+                "FTX+CRR+++Treatment of DVT,PE,AF,TIA - INR 2.0-3.0",
+                "ignore me"
         ));
 
         var labResultFreeTexts = assertThat(labResult.getFreeTexts()).hasSize(2);
 
         labResultFreeTexts
-            .map(FreeTextSegment::getType)
-            .isEqualTo(List.of(FreeTextType.COMPLEX_REFERENCE_RANGE, FreeTextType.COMPLEX_REFERENCE_RANGE));
+                .map(FreeTextSegment::getType)
+                .isEqualTo(List.of(FreeTextType.COMPLEX_REFERENCE_RANGE, FreeTextType.COMPLEX_REFERENCE_RANGE));
         labResultFreeTexts
-            .map(FreeTextSegment::getTexts)
-            .map(values -> values[0])
-            .isEqualTo(List.of("DVT Prophylaxis - INR 2.0-2.5", "Treatment of DVT,PE,AF,TIA - INR 2.0-3.0"));
+                .map(FreeTextSegment::getTexts)
+                .map(values -> values[0])
+                .isEqualTo(List.of("DVT Prophylaxis - INR 2.0-2.5", "Treatment of DVT,PE,AF,TIA - INR 2.0-3.0"));
     }
 
     @Test
     void testGetSequenceReference() {
         final var labResult = new LabResult(List.of(
-            "ignore me",
-            "RFF+ASL:1",
-            "ignore me"
+                "ignore me",
+                "RFF+ASL:1",
+                "ignore me"
         ));
         var labResultSequenceReference = assertThat(labResult.getSequenceReference()).isNotNull();
 
         labResultSequenceReference
-            .extracting(Reference::getNumber)
-            .isEqualTo("1");
+                .extracting(Reference::getNumber)
+                .isEqualTo("1");
         labResultSequenceReference
-            .extracting(Reference::getTarget)
-            .extracting(ReferenceType::getQualifier)
-            .isEqualTo("ASL");
+                .extracting(Reference::getTarget)
+                .extracting(ReferenceType::getQualifier)
+                .isEqualTo("ASL");
     }
 
     @Test
     void testGetResultReferenceRanges() {
         final var labResult = new LabResult(List.of(
-            "ignore me",
-            "S20+20",
-            "range #1 content",
-            "S20+20",
-            "range #2 content",
-            "UNT+18+00000003",
-            "ignore me"
+                "ignore me",
+                "S20+20",
+                "range #1 content",
+                "S20+20",
+                "range #2 content",
+                "UNT+18+00000003",
+                "ignore me"
         ));
         assertAll(
-            () -> assertThat(labResult.getResultReferenceRanges()).hasSize(2)
-                .first()
-                .extracting(ResultReferenceRange::getEdifactSegments)
-                .isEqualTo(List.of("S20+20", "range #1 content")),
-            () -> assertThat(labResult.getResultReferenceRanges())
-                .last()
-                .extracting(ResultReferenceRange::getEdifactSegments)
-                .isEqualTo(List.of("S20+20", "range #2 content"))
+                () -> assertThat(labResult.getResultReferenceRanges()).hasSize(2)
+                        .first()
+                        .extracting(ResultReferenceRange::getEdifactSegments)
+                        .isEqualTo(List.of("S20+20", "range #1 content")),
+                () -> assertThat(labResult.getResultReferenceRanges())
+                        .last()
+                        .extracting(ResultReferenceRange::getEdifactSegments)
+                        .isEqualTo(List.of("S20+20", "range #2 content"))
         );
     }
 
@@ -219,20 +219,20 @@ class LabResultTest {
     void testLazyGettersWhenMissing() {
         final var labResult = new LabResult(List.of());
         assertAll(
-            () -> assertThatThrownBy(labResult::getReportCode)
-                .isExactlyInstanceOf(MissingSegmentException.class)
-                .hasMessage("EDIFACT section is missing segment GIS"),
-            () -> assertThatThrownBy(labResult::getInvestigation)
-                .isExactlyInstanceOf(MissingSegmentException.class)
-                .hasMessage("EDIFACT section is missing segment INV+MQ"),
-            () -> assertThat(labResult.getSequenceDetails()).isEmpty(),
-            () -> assertThat(labResult.getInvestigationResult()).isEmpty(),
-            () -> assertThat(labResult.getTestStatus()).isEmpty(),
-            () -> assertThat(labResult.getFreeTexts()).isEmpty(),
-            () -> assertThatThrownBy(labResult::getSequenceReference)
-                .isExactlyInstanceOf(MissingSegmentException.class)
-                .hasMessage("EDIFACT section is missing segment RFF"),
-            () -> assertThat(labResult.getResultReferenceRanges()).isEmpty()
+                () -> assertThatThrownBy(labResult::getReportCode)
+                        .isExactlyInstanceOf(MissingSegmentException.class)
+                        .hasMessage("EDIFACT section is missing segment GIS"),
+                () -> assertThatThrownBy(labResult::getInvestigation)
+                        .isExactlyInstanceOf(MissingSegmentException.class)
+                        .hasMessage("EDIFACT section is missing segment INV+MQ"),
+                () -> assertThat(labResult.getSequenceDetails()).isEmpty(),
+                () -> assertThat(labResult.getInvestigationResult()).isEmpty(),
+                () -> assertThat(labResult.getTestStatus()).isEmpty(),
+                () -> assertThat(labResult.getFreeTexts()).isEmpty(),
+                () -> assertThatThrownBy(labResult::getSequenceReference)
+                        .isExactlyInstanceOf(MissingSegmentException.class)
+                        .hasMessage("EDIFACT section is missing segment RFF"),
+                () -> assertThat(labResult.getResultReferenceRanges()).isEmpty()
         );
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/PatientClinicalInfoTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/PatientClinicalInfoTest.java
@@ -21,33 +21,33 @@ class PatientClinicalInfoTest {
     @Test
     void testGetClinicalInformationCode() {
         final var patientInfo = new PatientClinicalInfo(List.of(
-            "ignore me",
-            "CIN+UN",
-            "ignore me"
+                "ignore me",
+                "CIN+UN",
+                "ignore me"
         ));
         assertThat(patientInfo.getCode())
-            .isNotNull()
-            .extracting(ClinicalInformationCode::getCode)
-            .isEqualTo("UN");
+                .isNotNull()
+                .extracting(ClinicalInformationCode::getCode)
+                .isEqualTo("UN");
     }
 
     @Test
     void testGetClinicalInformationFreeTexts() {
         final var patientInfo = new PatientClinicalInfo(List.of(
-            "ignore me",
-            "FTX+CID+++TIRED ALL THE TIME, LOW Hb",
-            "ignore me",
-            "FTX+CID+++PAINS HANDS AND FEET.",
-            "ignore me"
+                "ignore me",
+                "FTX+CID+++TIRED ALL THE TIME, LOW Hb",
+                "ignore me",
+                "FTX+CID+++PAINS HANDS AND FEET.",
+                "ignore me"
         ));
         var patientInfoFreeTexts = assertThat(patientInfo.getFreeTexts()).hasSize(2);
 
         patientInfoFreeTexts
-            .extracting(FreeTextSegment::getType)
-            .allMatch(value -> value == FreeTextType.CLINICAL_INFO);
+                .extracting(FreeTextSegment::getType)
+                .allMatch(value -> value == FreeTextType.CLINICAL_INFO);
         patientInfoFreeTexts.extracting(FreeTextSegment::getTexts)
-            .map(values -> values[0])
-            .isEqualTo(List.of("TIRED ALL THE TIME, LOW Hb", "PAINS HANDS AND FEET."));
+                .map(values -> values[0])
+                .isEqualTo(List.of("TIRED ALL THE TIME, LOW Hb", "PAINS HANDS AND FEET."));
     }
 
     @Test
@@ -55,10 +55,10 @@ class PatientClinicalInfoTest {
     void testLazyGettersWhenMissing() {
         final var patientInfo = new PatientClinicalInfo(List.of());
         assertAll(
-            () -> assertThatThrownBy(patientInfo::getCode)
-                .isExactlyInstanceOf(MissingSegmentException.class)
-                .hasMessage("EDIFACT section is missing segment CIN"),
-            () -> assertThat(patientInfo.getFreeTexts()).isEmpty()
+                () -> assertThatThrownBy(patientInfo::getCode)
+                        .isExactlyInstanceOf(MissingSegmentException.class)
+                        .hasMessage("EDIFACT section is missing segment CIN"),
+                () -> assertThat(patientInfo.getFreeTexts()).isEmpty()
         );
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/PatientDetailsTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/PatientDetailsTest.java
@@ -25,12 +25,12 @@ class PatientDetailsTest {
     @Test
     void testGetPersonName() {
         final var details = new PatientDetails(List.of(
-            "ignore me",
-            "PNA+PAT+9435492908:OPI+++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA",
-            "ignore me"
+                "ignore me",
+                "PNA+PAT+9435492908:OPI+++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA",
+                "ignore me"
         ));
         var name = assertThat(details.getName())
-            .isNotNull();
+                .isNotNull();
 
         name.extracting(PersonName::getNhsNumber).isEqualTo("9435492908");
         name.extracting(PersonName::getFirstForename).isEqualTo("SARAH");
@@ -38,15 +38,15 @@ class PatientDetailsTest {
         name.extracting(PersonName::getSurname).isEqualTo("KENNEDY");
         name.extracting(PersonName::getTitle).isEqualTo("MISS");
         name.extracting(PersonName::getPatientIdentificationType)
-            .isEqualTo(PatientIdentificationType.OFFICIAL_PATIENT_IDENTIFICATION);
+                .isEqualTo(PatientIdentificationType.OFFICIAL_PATIENT_IDENTIFICATION);
     }
 
     @Test
     void testGetPersonDateOfBirth() {
         final var details = new PatientDetails(List.of(
-            "ignore me",
-            "DTM+329:19450730:102",
-            "ignore me"
+                "ignore me",
+                "DTM+329:19450730:102",
+                "ignore me"
         ));
         var dateOfBirth = assertThat(details.getDateOfBirth()).isPresent();
         dateOfBirth.map(PersonDateOfBirth::getDateOfBirth).hasValue("1945-07-30");
@@ -56,14 +56,14 @@ class PatientDetailsTest {
     @Test
     void testGetPersonSex() {
         final var details = new PatientDetails(List.of(
-            "ignore me",
-            "PDI+2",
-            "ignore me"
+                "ignore me",
+                "PDI+2",
+                "ignore me"
         ));
         assertThat(details.getSex())
-            .isPresent()
-            .map(PersonSex::getGender)
-            .contains(Gender.FEMALE);
+                .isPresent()
+                .map(PersonSex::getGender)
+                .contains(Gender.FEMALE);
     }
 
     @Test
@@ -71,11 +71,11 @@ class PatientDetailsTest {
     void testLazyGettersWhenMissing() {
         final var details = new PatientDetails(List.of());
         assertAll(
-            () -> assertThatThrownBy(details::getName)
-                .isExactlyInstanceOf(MissingSegmentException.class)
-                .hasMessage("EDIFACT section is missing segment PNA+PAT"),
-            () -> assertThat(details.getDateOfBirth()).isEmpty(),
-            () -> assertThat(details.getSex()).isEmpty()
+                () -> assertThatThrownBy(details::getName)
+                        .isExactlyInstanceOf(MissingSegmentException.class)
+                        .hasMessage("EDIFACT section is missing segment PNA+PAT"),
+                () -> assertThat(details.getDateOfBirth()).isEmpty(),
+                () -> assertThat(details.getSex()).isEmpty()
         );
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/ResultReferenceRangeTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/ResultReferenceRangeTest.java
@@ -25,33 +25,33 @@ class ResultReferenceRangeTest {
     @Test
     void testGetRangeDetail() {
         final var range = new ResultReferenceRange(List.of(
-            "ignore me",
-            "RND+U+170+1100",
-            "ignore me"
+                "ignore me",
+                "RND+U+170+1100",
+                "ignore me"
         ));
         var rangeDetails = range.getDetails();
         assertThat(rangeDetails)
-            .isNotNull()
-            .extracting(RangeDetail::getLowerLimit)
-            .isEqualTo(BigDecimal.valueOf(EXPECTED_RANGE_LOWER_LIMIT));
+                .isNotNull()
+                .extracting(RangeDetail::getLowerLimit)
+                .isEqualTo(BigDecimal.valueOf(EXPECTED_RANGE_LOWER_LIMIT));
         assertThat(rangeDetails)
-            .isNotNull()
-            .extracting(RangeDetail::getUpperLimit)
-            .isEqualTo(BigDecimal.valueOf(EXPECTED_RANGE_UPPER_LIMIT));
+                .isNotNull()
+                .extracting(RangeDetail::getUpperLimit)
+                .isEqualTo(BigDecimal.valueOf(EXPECTED_RANGE_UPPER_LIMIT));
     }
 
     @Test
     void testGetReferencePopulationDefinitionFreeText() {
         final var range = new ResultReferenceRange(List.of(
-            "ignore me",
-            "FTX+RPD+++Equivocal",
-            "ignore me"
+                "ignore me",
+                "FTX+RPD+++Equivocal",
+                "ignore me"
         ));
         assertThat(range.getFreeTexts())
-            .isPresent()
-            .map(FreeTextSegment::getTexts)
-            .map(texts -> texts[0])
-            .contains("Equivocal");
+                .isPresent()
+                .map(FreeTextSegment::getTexts)
+                .map(texts -> texts[0])
+                .contains("Equivocal");
     }
 
     @Test
@@ -59,10 +59,10 @@ class ResultReferenceRangeTest {
     void testLazyGettersWhenMissing() {
         final var range = new ResultReferenceRange(List.of());
         assertAll(
-            () -> assertThatThrownBy(range::getDetails)
-                .isExactlyInstanceOf(MissingSegmentException.class)
-                .hasMessage("EDIFACT section is missing segment RND+U"),
-            () -> assertThat(range.getFreeTexts()).isEmpty()
+                () -> assertThatThrownBy(range::getDetails)
+                        .isExactlyInstanceOf(MissingSegmentException.class)
+                        .hasMessage("EDIFACT section is missing segment RND+U"),
+                () -> assertThat(range.getFreeTexts()).isEmpty()
         );
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/SegmentGroupTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/SegmentGroupTest.java
@@ -24,26 +24,26 @@ class SegmentGroupTest {
     void testSplitOnlyKey() {
         final List<List<String>> result = splitMultipleSegmentGroups(List.of("key", "key"), "key");
         assertThat(result)
-            .hasSize(2)
-            .allMatch(List.of("key")::equals);
+                .hasSize(2)
+                .allMatch(List.of("key")::equals);
     }
 
     @Test
     void testSplitOnlyOneGroup() {
         final List<List<String>> result = splitMultipleSegmentGroups(List.of("key", "content 1", "content 2"), "key");
         assertThat(result)
-            .hasSize(1)
-            .contains(List.of("key", "content 1", "content 2"));
+                .hasSize(1)
+                .contains(List.of("key", "content 1", "content 2"));
     }
 
     @Test
     void testSplitMultipleGroups() {
         final List<List<String>> result = splitMultipleSegmentGroups(
-            List.of("key", "content 1", "key", "content 2"), "key");
+                List.of("key", "content 1", "key", "content 2"), "key");
         assertThat(result)
-            .hasSize(2)
-            .contains(
-                List.of("key", "content 1"),
-                List.of("key", "content 2"));
+                .hasSize(2)
+                .contains(
+                        List.of("key", "content 1"),
+                        List.of("key", "content 2"));
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/ServiceReportDetailsTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/ServiceReportDetailsTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 class ServiceReportDetailsTest {
     private static final LocalDateTime EXPECTED_DATE_TIME =
-        LocalDateTime.of(2020, 1, 28, 9, 57);
+            LocalDateTime.of(2020, 1, 28, 9, 57);
 
     @Test
     void testIndicator() {
@@ -28,74 +28,74 @@ class ServiceReportDetailsTest {
     @Test
     void testGetDiagnosticReportCode() {
         final var report = new ServiceReportDetails(List.of(
-            "ignore me",
-            "GIS+N",
-            "ignore me"
+                "ignore me",
+                "GIS+N",
+                "ignore me"
         ));
         assertThat(report.getCode())
-            .isNotNull()
-            .extracting(DiagnosticReportCode::getCode)
-            .isEqualTo("N");
+                .isNotNull()
+                .extracting(DiagnosticReportCode::getCode)
+                .isEqualTo("N");
     }
 
     @Test
     void testGetReferenceDiagnosticReport() {
         final var report = new ServiceReportDetails(List.of(
-            "ignore me",
-            "RFF+SRI:13/CH001137K/211010191093",
-            "ignore me"
+                "ignore me",
+                "RFF+SRI:13/CH001137K/211010191093",
+                "ignore me"
         ));
         var reportReference = assertThat(report.getReference()).isNotNull();
 
         reportReference
-            .extracting(Reference::getNumber)
-            .isEqualTo("13/CH001137K/211010191093");
+                .extracting(Reference::getNumber)
+                .isEqualTo("13/CH001137K/211010191093");
         reportReference
-            .extracting(Reference::getTarget)
-            .extracting(ReferenceType::getQualifier)
-            .isEqualTo("SRI");
+                .extracting(Reference::getTarget)
+                .extracting(ReferenceType::getQualifier)
+                .isEqualTo("SRI");
     }
 
     @Test
     void testGetDiagnosticReportStatus() {
         final var report = new ServiceReportDetails(List.of(
-            "ignore me",
-            "STS++UN",
-            "ignore me"
+                "ignore me",
+                "STS++UN",
+                "ignore me"
         ));
         assertThat(report.getStatus())
-            .isNotNull()
-            .extracting(DiagnosticReportStatus::getEvent)
-            .isEqualTo(ReportStatusCode.UNSPECIFIED);
+                .isNotNull()
+                .extracting(DiagnosticReportStatus::getEvent)
+                .isEqualTo(ReportStatusCode.UNSPECIFIED);
     }
 
     @Test
     void testGetDiagnosticReportDateIssued() {
         final var report = new ServiceReportDetails(List.of(
-            "ignore me",
-            "DTM+ISR:202001280957:203",
-            "ignore me"
+                "ignore me",
+                "DTM+ISR:202001280957:203",
+                "ignore me"
         ));
         var reportDateIssued = assertThat(report.getDateIssued()).isNotNull();
 
         reportDateIssued
-            .extracting(DiagnosticReportDateIssued::getDateIssued)
-            .isEqualTo(EXPECTED_DATE_TIME);
+                .extracting(DiagnosticReportDateIssued::getDateIssued)
+                .isEqualTo(EXPECTED_DATE_TIME);
     }
 
     @Test
     void testGetInvestigationSubject() {
         final var report = new ServiceReportDetails(List.of(
-            "ignore me",
-            "S06",
-            "investigation subject content",
-            "UNT+18+00000003",
-            "ignore me"
+                "ignore me",
+                "S06",
+                "investigation subject content",
+                "UNT+18+00000003",
+                "ignore me"
         ));
         assertThat(report.getSubject())
-            .isNotNull()
-            .extracting(InvestigationSubject::getEdifactSegments)
-            .isEqualTo(List.of("S06", "investigation subject content"));
+                .isNotNull()
+                .extracting(InvestigationSubject::getEdifactSegments)
+                .isEqualTo(List.of("S06", "investigation subject content"));
     }
 
     @Test
@@ -103,22 +103,22 @@ class ServiceReportDetailsTest {
     void testLazyGettersWhenMissing() {
         final var report = new ServiceReportDetails(List.of());
         assertAll(
-            () -> assertThatThrownBy(report::getCode)
-                .isExactlyInstanceOf(MissingSegmentException.class)
-                .hasMessage("EDIFACT section is missing segment GIS"),
-            () -> assertThatThrownBy(report::getReference)
-                .isExactlyInstanceOf(MissingSegmentException.class)
-                .hasMessage("EDIFACT section is missing segment RFF+SRI"),
-            () -> assertThatThrownBy(report::getDateIssued)
-                .isExactlyInstanceOf(MissingSegmentException.class)
-                .hasMessage("EDIFACT section is missing segment DTM+ISR"),
-            () -> assertThatThrownBy(report::getStatus)
-                .isExactlyInstanceOf(MissingSegmentException.class)
-                .hasMessage("EDIFACT section is missing segment STS"),
-            () -> assertThat(report.getSubject())
-                .isNotNull()
-                .extracting(InvestigationSubject::getEdifactSegments)
-                .isEqualTo(List.of())
+                () -> assertThatThrownBy(report::getCode)
+                        .isExactlyInstanceOf(MissingSegmentException.class)
+                        .hasMessage("EDIFACT section is missing segment GIS"),
+                () -> assertThatThrownBy(report::getReference)
+                        .isExactlyInstanceOf(MissingSegmentException.class)
+                        .hasMessage("EDIFACT section is missing segment RFF+SRI"),
+                () -> assertThatThrownBy(report::getDateIssued)
+                        .isExactlyInstanceOf(MissingSegmentException.class)
+                        .hasMessage("EDIFACT section is missing segment DTM+ISR"),
+                () -> assertThatThrownBy(report::getStatus)
+                        .isExactlyInstanceOf(MissingSegmentException.class)
+                        .hasMessage("EDIFACT section is missing segment STS"),
+                () -> assertThat(report.getSubject())
+                        .isNotNull()
+                        .extracting(InvestigationSubject::getEdifactSegments)
+                        .isEqualTo(List.of())
         );
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/SpecimenDetailsTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/segmentgroup/SpecimenDetailsTest.java
@@ -30,139 +30,139 @@ class SpecimenDetailsTest {
     @Test
     void testGetSequenceDetails() {
         final var specimen = new SpecimenDetails(List.of(
-            "ignore me",
-            "SEQ++123ABC",
-            "ignore me"
+                "ignore me",
+                "SEQ++123ABC",
+                "ignore me"
         ));
         assertThat(specimen.getSequenceDetails())
-            .isPresent()
-            .map(SequenceDetails::getNumber)
-            .contains("123ABC");
+                .isPresent()
+                .map(SequenceDetails::getNumber)
+                .contains("123ABC");
     }
 
     @Test
     void testGetSpecimenCharacteristicType() {
         final var specimen = new SpecimenDetails(List.of(
-            "ignore me",
-            "SPC+TSP+:::BLOOD & URINE",
-            "ignore me"
+                "ignore me",
+                "SPC+TSP+:::BLOOD & URINE",
+                "ignore me"
         ));
         assertThat(specimen.getCharacteristicType())
-            .isNotNull()
-            .extracting(SpecimenCharacteristicType::getTypeOfSpecimen)
-            .isEqualTo("BLOOD & URINE");
+                .isNotNull()
+                .extracting(SpecimenCharacteristicType::getTypeOfSpecimen)
+                .isEqualTo("BLOOD & URINE");
     }
 
     @Test
     void testGetSpecimenReferenceByServiceRequester() {
         final var specimen = new SpecimenDetails(List.of(
-            "ignore me",
-            "RFF+RTI:CH000064LX",
-            "ignore me"
+                "ignore me",
+                "RFF+RTI:CH000064LX",
+                "ignore me"
         ));
         var serviceRequesterReference = assertThat(specimen.getServiceRequesterReference())
-            .isPresent();
+                .isPresent();
 
         serviceRequesterReference
-            .map(Reference::getNumber)
-            .isEqualTo(Optional.of("CH000064LX"));
+                .map(Reference::getNumber)
+                .isEqualTo(Optional.of("CH000064LX"));
         serviceRequesterReference
-            .map(Reference::getTarget)
-            .map(ReferenceType::getQualifier)
-            .hasValue("RTI");
+                .map(Reference::getTarget)
+                .map(ReferenceType::getQualifier)
+                .hasValue("RTI");
     }
 
     @Test
     void testGetSpecimenReferenceByServiceProvider() {
         final var specimen = new SpecimenDetails(List.of(
-            "ignore me",
-            "RFF+STI:CH000064LX",
-            "ignore me"
+                "ignore me",
+                "RFF+STI:CH000064LX",
+                "ignore me"
         ));
         var serviceProviderReference = assertThat(specimen.getServiceProviderReference())
-            .isPresent();
+                .isPresent();
 
         serviceProviderReference
-            .map(Reference::getNumber)
-            .hasValue("CH000064LX");
+                .map(Reference::getNumber)
+                .hasValue("CH000064LX");
         serviceProviderReference
-            .map(Reference::getTarget)
-            .map(ReferenceType::getQualifier)
-            .hasValue("STI");
+                .map(Reference::getTarget)
+                .map(ReferenceType::getQualifier)
+                .hasValue("STI");
     }
 
     @Test
     void testGetSpecimenQuantity() {
         final var specimen = new SpecimenDetails(List.of(
-            "ignore me",
-            "QTY+SVO:1750+:::mL",
-            "ignore me"
+                "ignore me",
+                "QTY+SVO:1750+:::mL",
+                "ignore me"
         ));
         var specimenQuantity = assertThat(specimen.getQuantity()).isPresent();
 
         specimenQuantity
-            .map(SpecimenQuantity::getQuantity)
-            .hasValue(EXPECTED_SPECIMEN_QUANTITY);
+                .map(SpecimenQuantity::getQuantity)
+                .hasValue(EXPECTED_SPECIMEN_QUANTITY);
         specimenQuantity
-            .map(SpecimenQuantity::getQuantityUnitOfMeasure)
-            .hasValue("mL");
+                .map(SpecimenQuantity::getQuantityUnitOfMeasure)
+                .hasValue("mL");
     }
 
     @Test
     void testGetSpecimenCollectionDateTime() {
         final var specimen = new SpecimenDetails(List.of(
-            "ignore me",
-            "DTM+SCO:20100223:102",
-            "ignore me"
+                "ignore me",
+                "DTM+SCO:20100223:102",
+                "ignore me"
         ));
         var specimenCollectionDateTime = assertThat(specimen.getCollectionDateTime()).isPresent();
 
         specimenCollectionDateTime
-            .map(SpecimenCollectionDateTime::getCollectionDateTime)
-            .hasValue("20100223");
+                .map(SpecimenCollectionDateTime::getCollectionDateTime)
+                .hasValue("20100223");
         specimenCollectionDateTime
-            .map(SpecimenCollectionDateTime::getDateFormat)
-            .hasValue(DateFormat.CCYYMMDD);
+                .map(SpecimenCollectionDateTime::getDateFormat)
+                .hasValue(DateFormat.CCYYMMDD);
     }
 
     @Test
     void testGetSpecimenCollectionReceiptDateTime() {
         final var specimen = new SpecimenDetails(List.of(
-            "ignore me",
-            "DTM+SRI:201002241541:203",
-            "ignore me"
+                "ignore me",
+                "DTM+SRI:201002241541:203",
+                "ignore me"
         ));
 
         var specimenCollectionReceiptDateTime = assertThat(specimen.getCollectionReceiptDateTime()).isPresent();
 
         specimenCollectionReceiptDateTime
-            .map(SpecimenCollectionReceiptDateTime::getCollectionReceiptDateTime)
-            .hasValue("201002241541");
+                .map(SpecimenCollectionReceiptDateTime::getCollectionReceiptDateTime)
+                .hasValue("201002241541");
         specimenCollectionReceiptDateTime
-            .map(SpecimenCollectionReceiptDateTime::getDateFormat)
-            .hasValue(DateFormat.CCYYMMDDHHMM);
+                .map(SpecimenCollectionReceiptDateTime::getDateFormat)
+                .hasValue(DateFormat.CCYYMMDDHHMM);
     }
 
     @Test
     void testGetServiceProviderCommentFreeTexts() {
         final var specimen = new SpecimenDetails(List.of(
-            "ignore me",
-            "FTX+SPC+++red blood cell seen",
-            "ignore me",
-            "FTX+SPC+++Note low platelets",
-            "ignore me"
+                "ignore me",
+                "FTX+SPC+++red blood cell seen",
+                "ignore me",
+                "FTX+SPC+++Note low platelets",
+                "ignore me"
         ));
 
         var specimenFreeTexts = assertThat(specimen.getFreeTexts()).hasSize(2);
 
         specimenFreeTexts
-            .map(FreeTextSegment::getTexts)
-            .map(freeTexts -> freeTexts[0])
-            .contains("red blood cell seen");
+                .map(FreeTextSegment::getTexts)
+                .map(freeTexts -> freeTexts[0])
+                .contains("red blood cell seen");
         specimenFreeTexts
-            .map(FreeTextSegment::getTexts)
-            .map(freeTexts -> freeTexts[0])
-            .contains("Note low platelets");
+                .map(FreeTextSegment::getTexts)
+                .map(freeTexts -> freeTexts[0])
+                .contains("Note low platelets");
     }
 
     @Test
@@ -170,16 +170,16 @@ class SpecimenDetailsTest {
     void testLazyGettersWhenMissing() {
         final var specimen = new SpecimenDetails(List.of());
         assertAll(
-            () -> assertThat(specimen.getSequenceDetails()).isEmpty(),
-            () -> assertThatThrownBy(specimen::getCharacteristicType)
-                .isExactlyInstanceOf(MissingSegmentException.class)
-                .hasMessage("EDIFACT section is missing segment SPC+TSP"),
-            () -> assertThat(specimen.getServiceRequesterReference()).isEmpty(),
-            () -> assertThat(specimen.getServiceProviderReference()).isEmpty(),
-            () -> assertThat(specimen.getQuantity()).isEmpty(),
-            () -> assertThat(specimen.getCollectionDateTime()).isEmpty(),
-            () -> assertThat(specimen.getCollectionReceiptDateTime()).isEmpty(),
-            () -> assertThat(specimen.getFreeTexts()).isEmpty()
+                () -> assertThat(specimen.getSequenceDetails()).isEmpty(),
+                () -> assertThatThrownBy(specimen::getCharacteristicType)
+                        .isExactlyInstanceOf(MissingSegmentException.class)
+                        .hasMessage("EDIFACT section is missing segment SPC+TSP"),
+                () -> assertThat(specimen.getServiceRequesterReference()).isEmpty(),
+                () -> assertThat(specimen.getServiceProviderReference()).isEmpty(),
+                () -> assertThat(specimen.getQuantity()).isEmpty(),
+                () -> assertThat(specimen.getCollectionDateTime()).isEmpty(),
+                () -> assertThat(specimen.getCollectionReceiptDateTime()).isEmpty(),
+                () -> assertThat(specimen.getFreeTexts()).isEmpty()
         );
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/outbound/queue/GpOutboundQueueServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/outbound/queue/GpOutboundQueueServiceTest.java
@@ -63,8 +63,8 @@ class GpOutboundQueueServiceTest {
         gpOutboundQueueService.publish(bundle);
 
         assertAll(
-            () -> verify(serializer).serialize(bundle),
-            () -> verify(jmsTemplate).send(eq(gpOutboundQueueName), messageCreatorArgumentCaptor.capture())
+                () -> verify(serializer).serialize(bundle),
+                () -> verify(jmsTemplate).send(eq(gpOutboundQueueName), messageCreatorArgumentCaptor.capture())
         );
 
         when(session.createTextMessage(serializedData)).thenReturn(textMessage);
@@ -72,9 +72,9 @@ class GpOutboundQueueServiceTest {
         messageCreatorArgumentCaptor.getValue().createMessage(session);
 
         assertAll(
-            () -> verify(session).createTextMessage(eq(serializedData)),
-            () -> verify(textMessage).setStringProperty(JmsHeaders.CORRELATION_ID, CONSERVATION_ID),
-            () -> verify(correlationIdService).getCurrentCorrelationId()
+                () -> verify(session).createTextMessage(eq(serializedData)),
+                () -> verify(textMessage).setStringProperty(JmsHeaders.CORRELATION_ID, CONSERVATION_ID),
+                () -> verify(correlationIdService).getCurrentCorrelationId()
         );
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/outbound/queue/MeshOutboundQueueServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/outbound/queue/MeshOutboundQueueServiceTest.java
@@ -81,8 +81,8 @@ class MeshOutboundQueueServiceTest {
             meshOutboundQueueService.publish(outboundMeshMessage);
 
             assertAll(
-                () -> verify(outboundMeshMessage).setMessageSentTimestamp(TIMESTAMP),
-                () -> verify(jmsTemplate).send(eq("queue"), messageCreatorCaptor.capture())
+                    () -> verify(outboundMeshMessage).setMessageSentTimestamp(TIMESTAMP),
+                    () -> verify(jmsTemplate).send(eq("queue"), messageCreatorCaptor.capture())
             );
 
             final var mockSession = mock(Session.class);
@@ -94,8 +94,8 @@ class MeshOutboundQueueServiceTest {
             final Message result = messageCreatorCaptor.getValue().createMessage(mockSession);
 
             assertAll(
-                () -> verify(mockTextMessage).setStringProperty(JmsHeaders.CORRELATION_ID, "CorrelationID"),
-                () -> assertEquals(mockTextMessage, result)
+                    () -> verify(mockTextMessage).setStringProperty(JmsHeaders.CORRELATION_ID, "CorrelationID"),
+                    () -> assertEquals(mockTextMessage, result)
             );
         }
     }
@@ -116,10 +116,10 @@ class MeshOutboundQueueServiceTest {
             meshOutboundQueueService.receive(message);
 
             assertAll(
-                () -> verify(correlationIdService).applyCorrelationId("CorrelationID"),
-                () -> verify(meshClient).authenticate(),
-                () -> verify(meshClient).sendEdifactMessage(outboundMeshMessage),
-                () -> verify(correlationIdService).resetCorrelationId()
+                    () -> verify(correlationIdService).applyCorrelationId("CorrelationID"),
+                    () -> verify(meshClient).authenticate(),
+                    () -> verify(meshClient).sendEdifactMessage(outboundMeshMessage),
+                    () -> verify(correlationIdService).resetCorrelationId()
             );
         }
 
@@ -128,7 +128,7 @@ class MeshOutboundQueueServiceTest {
         void testReceiveFailsToApplyCorrelationId() {
             final var message = mock(Message.class);
             when(message.getStringProperty(JmsHeaders.CORRELATION_ID))
-                .thenThrow(new JMSException("Expected exception"));
+                    .thenThrow(new JMSException("Expected exception"));
             when(message.getBody(String.class)).thenReturn("Message Body");
 
             final var outboundMeshMessage = mock(OutboundMeshMessage.class);
@@ -137,10 +137,10 @@ class MeshOutboundQueueServiceTest {
             meshOutboundQueueService.receive(message);
 
             assertAll(
-                () -> verify(correlationIdService, never()).applyCorrelationId("CorrelationID"),
-                () -> verify(meshClient).authenticate(),
-                () -> verify(meshClient).sendEdifactMessage(outboundMeshMessage),
-                () -> verify(correlationIdService).resetCorrelationId()
+                    () -> verify(correlationIdService, never()).applyCorrelationId("CorrelationID"),
+                    () -> verify(meshClient).authenticate(),
+                    () -> verify(meshClient).sendEdifactMessage(outboundMeshMessage),
+                    () -> verify(correlationIdService).resetCorrelationId()
             );
         }
 
@@ -154,14 +154,14 @@ class MeshOutboundQueueServiceTest {
 
             final var outboundMeshMessage = mock(OutboundMeshMessage.class);
             when(objectMapper.readValue("Message Body", OutboundMeshMessage.class))
-                .thenThrow(new JsonMappingException("Expected exception"));
+                    .thenThrow(new JsonMappingException("Expected exception"));
 
             assertAll(
-                () -> assertThrows(JsonMappingException.class, () -> meshOutboundQueueService.receive(message)),
-                () -> verify(correlationIdService).applyCorrelationId("CorrelationID"),
-                () -> verify(meshClient, never()).authenticate(),
-                () -> verify(meshClient, never()).sendEdifactMessage(outboundMeshMessage),
-                () -> verify(correlationIdService).resetCorrelationId()
+                    () -> assertThrows(JsonMappingException.class, () -> meshOutboundQueueService.receive(message)),
+                    () -> verify(correlationIdService).applyCorrelationId("CorrelationID"),
+                    () -> verify(meshClient, never()).authenticate(),
+                    () -> verify(meshClient, never()).sendEdifactMessage(outboundMeshMessage),
+                    () -> verify(correlationIdService).resetCorrelationId()
             );
         }
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/outbound/queue/ObjectSerializerTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/outbound/queue/ObjectSerializerTest.java
@@ -33,7 +33,7 @@ class ObjectSerializerTest {
     @Test
     void serializeInvalidDataTypeToStringThrowsException() {
         final UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
-            () -> objectSerializer.serialize(new Object()));
+                () -> objectSerializer.serialize(new Object()));
 
         assertEquals("Data type Object is not supported", exception.getMessage());
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/sequence/SequenceRepositoryTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/sequence/SequenceRepositoryTest.java
@@ -30,7 +30,7 @@ class SequenceRepositoryTest {
     @Test
     void when_getNextKey_expect_correctValue() {
         when(mongoOperations.findAndModify(any(Query.class), any(Update.class), any(FindAndModifyOptions.class),
-            eq(OutboundSequenceId.class))).thenReturn(SEQUENCE_ID);
+                eq(OutboundSequenceId.class))).thenReturn(SEQUENCE_ID);
 
         assertThat(sequenceRepository.getNext(NEW_KEY)).isEqualTo(1L);
     }
@@ -38,13 +38,13 @@ class SequenceRepositoryTest {
     @Test
     void when_getMaxNextKey_expect_valueReset() {
         when(mongoOperations.findAndModify(
-            any(Query.class),
-            any(Update.class),
-            any(FindAndModifyOptions.class),
-            eq(OutboundSequenceId.class)
+                any(Query.class),
+                any(Update.class),
+                any(FindAndModifyOptions.class),
+                eq(OutboundSequenceId.class)
         ))
-            .thenReturn(new OutboundSequenceId(MAX_KEY, SequenceRepository.MAX_SEQUENCE_NUMBER))
-            .thenReturn(new OutboundSequenceId(MAX_KEY, SequenceRepository.MAX_SEQUENCE_NUMBER + 1));
+                .thenReturn(new OutboundSequenceId(MAX_KEY, SequenceRepository.MAX_SEQUENCE_NUMBER))
+                .thenReturn(new OutboundSequenceId(MAX_KEY, SequenceRepository.MAX_SEQUENCE_NUMBER + 1));
 
         assertThat(sequenceRepository.getNext(MAX_KEY)).isEqualTo(1L);
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/sequence/SequenceServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/sequence/SequenceServiceTest.java
@@ -26,27 +26,27 @@ class SequenceServiceTest {
     void when_generateInterchangeId_expect_correctValue() {
         when(sequenceRepository.getNext(INTERCHANGE_ID)).thenReturn(SEQ_VALUE);
         assertThat(sequenceService.generateInterchangeSequence("sender", "recipient"))
-            .isEqualTo(SEQ_VALUE);
+                .isEqualTo(SEQ_VALUE);
     }
 
     @Test
     void when_generateMessageId_expect_correctValue() {
         when(sequenceRepository.getNext(MESSAGE_ID)).thenReturn(SEQ_VALUE);
         assertThat(sequenceService.generateMessageSequence("sender", "recipient"))
-            .isEqualTo(SEQ_VALUE);
+                .isEqualTo(SEQ_VALUE);
     }
 
     @Test
     void when_generateIdsForInvalidSender_expect_exception() {
         assertThatThrownBy(() -> sequenceService.generateInterchangeSequence(null, "recipient"))
-            .isExactlyInstanceOf(SequenceException.class)
-            .hasMessage("Sender or recipient not valid. Sender: null, recipient: recipient");
+                .isExactlyInstanceOf(SequenceException.class)
+                .hasMessage("Sender or recipient not valid. Sender: null, recipient: recipient");
     }
 
     @Test
     void when_generateIdsForInvalidRecipient_expect_exception() {
         assertThatThrownBy(() -> sequenceService.generateInterchangeSequence("sender", ""))
-            .isExactlyInstanceOf(SequenceException.class)
-            .hasMessage("Sender or recipient not valid. Sender: sender, recipient: ");
+                .isExactlyInstanceOf(SequenceException.class)
+                .hasMessage("Sender or recipient not valid. Sender: sender, recipient: ");
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/BundleMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/BundleMapperTest.java
@@ -52,8 +52,8 @@ class BundleMapperTest {
         final var mockRequester = mock(Practitioner.class);
         lenient().when(mockRequester.getId()).thenReturn(SOME_UUID);
         pathologyRecordBuilder = PathologyRecord.builder()
-            .requester(mockRequester)
-            .patient(mock(Patient.class));
+                .requester(mockRequester)
+                .patient(mock(Patient.class));
     }
 
     @Test
@@ -64,19 +64,19 @@ class BundleMapperTest {
         final var bundle = bundleMapper.mapToBundle(pathologyRecordBuilder.build());
 
         final var practitionerBundleEntries = bundle.getEntry().stream()
-            .filter(entry -> entry.getResource() instanceof Practitioner)
-            .collect(Collectors.toList());
+                .filter(entry -> entry.getResource() instanceof Practitioner)
+                .collect(Collectors.toList());
         final var practitioners = practitionerBundleEntries.stream()
-            .map(BundleEntryComponent::getResource)
-            .map(Practitioner.class::cast)
-            .collect(Collectors.toList());
+                .map(BundleEntryComponent::getResource)
+                .map(Practitioner.class::cast)
+                .collect(Collectors.toList());
 
         assertAll(
-            () -> verifyBundle(bundle),
-            () -> assertThat(practitioners).hasSize(1).contains(mockRequester),
-            () -> assertThat(practitionerBundleEntries).first()
-                .extracting(BundleEntryComponent::getFullUrl)
-                .isEqualTo(FULL_URL)
+                () -> verifyBundle(bundle),
+                () -> assertThat(practitioners).hasSize(1).contains(mockRequester),
+                () -> assertThat(practitionerBundleEntries).first()
+                        .extracting(BundleEntryComponent::getFullUrl)
+                        .isEqualTo(FULL_URL)
         );
     }
 
@@ -88,19 +88,19 @@ class BundleMapperTest {
         final Bundle bundle = bundleMapper.mapToBundle(pathologyRecordBuilder.build());
 
         final var patientBundleEntries = bundle.getEntry().stream()
-            .filter(entry -> entry.getResource() instanceof Patient)
-            .collect(Collectors.toList());
+                .filter(entry -> entry.getResource() instanceof Patient)
+                .collect(Collectors.toList());
         final var patients = patientBundleEntries.stream()
-            .map(BundleEntryComponent::getResource)
-            .map(Patient.class::cast)
-            .collect(Collectors.toList());
+                .map(BundleEntryComponent::getResource)
+                .map(Patient.class::cast)
+                .collect(Collectors.toList());
 
         assertAll(
-            () -> verifyBundle(bundle),
-            () -> assertThat(patients).hasSize(1).contains(mockPatient),
-            () -> assertThat(patientBundleEntries).first()
-                .extracting(BundleEntryComponent::getFullUrl)
-                .isEqualTo(FULL_URL)
+                () -> verifyBundle(bundle),
+                () -> assertThat(patients).hasSize(1).contains(mockPatient),
+                () -> assertThat(patientBundleEntries).first()
+                        .extracting(BundleEntryComponent::getFullUrl)
+                        .isEqualTo(FULL_URL)
         );
     }
 
@@ -112,20 +112,20 @@ class BundleMapperTest {
         final var bundle = bundleMapper.mapToBundle(pathologyRecordBuilder.build());
 
         final var performerBundleEntries = bundle.getEntry().stream()
-            .filter(entry -> entry.getResource() instanceof Practitioner)
-            .collect(Collectors.toList());
+                .filter(entry -> entry.getResource() instanceof Practitioner)
+                .collect(Collectors.toList());
         final var practitioners = performerBundleEntries.stream()
-            .map(BundleEntryComponent::getResource)
-            .map(Practitioner.class::cast)
-            .collect(Collectors.toList());
+                .map(BundleEntryComponent::getResource)
+                .map(Practitioner.class::cast)
+                .collect(Collectors.toList());
 
         assertAll(
-            () -> verifyBundle(bundle),
-            () -> assertThat(practitioners).hasSize(2) // includes required requester
-                .contains(mockPerformer),
-            () -> assertThat(performerBundleEntries)
-                .extracting(BundleEntryComponent::getFullUrl)
-                .allMatch(FULL_URL::equals)
+                () -> verifyBundle(bundle),
+                () -> assertThat(practitioners).hasSize(2) // includes required requester
+                        .contains(mockPerformer),
+                () -> assertThat(performerBundleEntries)
+                        .extracting(BundleEntryComponent::getFullUrl)
+                        .allMatch(FULL_URL::equals)
         );
     }
 
@@ -138,31 +138,31 @@ class BundleMapperTest {
         final var bundle = bundleMapper.mapToBundle(pathologyRecordBuilder.build());
 
         final var specimenBundleEntries = bundle.getEntry().stream()
-            .filter(entry -> entry.getResource() instanceof Specimen)
-            .collect(Collectors.toList());
+                .filter(entry -> entry.getResource() instanceof Specimen)
+                .collect(Collectors.toList());
         final var specimens = specimenBundleEntries.stream()
-            .map(BundleEntryComponent::getResource)
-            .map(Specimen.class::cast)
-            .collect(Collectors.toList());
+                .map(BundleEntryComponent::getResource)
+                .map(Specimen.class::cast)
+                .collect(Collectors.toList());
 
         assertAll(
-            () -> verifyBundle(bundle),
-            () -> assertThat(specimens).hasSize(2)
-                .contains(mockSpecimen1, mockSpecimen2),
-            () -> assertThat(specimenBundleEntries)
-                .extracting(BundleEntryComponent::getFullUrl)
-                .allMatch(FULL_URL::equals)
+                () -> verifyBundle(bundle),
+                () -> assertThat(specimens).hasSize(2)
+                        .contains(mockSpecimen1, mockSpecimen2),
+                () -> assertThat(specimenBundleEntries)
+                        .extracting(BundleEntryComponent::getFullUrl)
+                        .allMatch(FULL_URL::equals)
         );
     }
 
     private void verifyBundle(Bundle bundle) {
         assertAll(
-            () -> assertThat(bundle.getMeta().getLastUpdated()).isNotNull(),
-            () -> assertThat(bundle.getMeta().getProfile().get(0).asStringValue())
-                .isEqualTo("https://fhir.nhs.uk/STU3/StructureDefinition/ITK-Message-Bundle-1"),
-            () -> assertThat(bundle.getIdentifier().getSystem()).isEqualTo("https://tools.ietf.org/html/rfc4122"),
-            () -> assertThat(bundle.getIdentifier().getValue()).isEqualTo(SOME_UUID),
-            () -> assertThat(bundle.getType()).isEqualTo(Bundle.BundleType.MESSAGE)
+                () -> assertThat(bundle.getMeta().getLastUpdated()).isNotNull(),
+                () -> assertThat(bundle.getMeta().getProfile().get(0).asStringValue())
+                        .isEqualTo("https://fhir.nhs.uk/STU3/StructureDefinition/ITK-Message-Bundle-1"),
+                () -> assertThat(bundle.getIdentifier().getSystem()).isEqualTo("https://tools.ietf.org/html/rfc4122"),
+                () -> assertThat(bundle.getIdentifier().getValue()).isEqualTo(SOME_UUID),
+                () -> assertThat(bundle.getType()).isEqualTo(Bundle.BundleType.MESSAGE)
         );
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/DateFormatMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/DateFormatMapperTest.java
@@ -16,17 +16,17 @@ class DateFormatMapperTest {
     void testCCYY() {
         var result = new DateFormatMapper().mapToDateTimeType(DateFormat.CCYY, "2021");
         assertThat(result)
-            .isNotNull()
-            .extracting(BaseDateTimeType::getYear)
-            .isEqualTo(2021);
+                .isNotNull()
+                .extracting(BaseDateTimeType::getYear)
+                .isEqualTo(2021);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"wrong", "1", "202101"})
     void testCCYYFailure(String badDate) {
         assertThatThrownBy(() -> new DateFormatMapper().mapToDateTimeType(DateFormat.CCYY, badDate))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Cannot interpret %s as CCYY", badDate);
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Cannot interpret %s as CCYY", badDate);
     }
 
     @Test
@@ -34,8 +34,8 @@ class DateFormatMapperTest {
         var result = new DateFormatMapper().mapToDateTimeType(DateFormat.CCYYMM, "202012");
         final var assertResult = assertThat(result).isNotNull();
         assertAll(
-            () -> assertResult.extracting(BaseDateTimeType::getYear).isEqualTo(2020),
-            () -> assertResult.extracting(BaseDateTimeType::getMonth).isEqualTo(11)
+                () -> assertResult.extracting(BaseDateTimeType::getYear).isEqualTo(2020),
+                () -> assertResult.extracting(BaseDateTimeType::getMonth).isEqualTo(11)
         );
     }
 
@@ -43,8 +43,8 @@ class DateFormatMapperTest {
     @ValueSource(strings = {"wrong", "2", "20210101"})
     void testCCYYMMFailure(String badDate) {
         assertThatThrownBy(() -> new DateFormatMapper().mapToDateTimeType(DateFormat.CCYYMM, badDate))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Cannot interpret %s as CCYYMM", badDate);
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Cannot interpret %s as CCYYMM", badDate);
     }
 
     @Test
@@ -52,9 +52,9 @@ class DateFormatMapperTest {
         var result = new DateFormatMapper().mapToDateTimeType(DateFormat.CCYYMMDD, "20191130");
         final var assertResult = assertThat(result).isNotNull();
         assertAll(
-            () -> assertResult.extracting(BaseDateTimeType::getYear).isEqualTo(2019),
-            () -> assertResult.extracting(BaseDateTimeType::getMonth).isEqualTo(10),
-            () -> assertResult.extracting(BaseDateTimeType::getDay).isEqualTo(30)
+                () -> assertResult.extracting(BaseDateTimeType::getYear).isEqualTo(2019),
+                () -> assertResult.extracting(BaseDateTimeType::getMonth).isEqualTo(10),
+                () -> assertResult.extracting(BaseDateTimeType::getDay).isEqualTo(30)
         );
     }
 
@@ -62,8 +62,8 @@ class DateFormatMapperTest {
     @ValueSource(strings = {"wrong", "1", "2101011230"})
     void testCCYYMMDDFailure(String badDate) {
         assertThatThrownBy(() -> new DateFormatMapper().mapToDateTimeType(DateFormat.CCYYMMDD, badDate))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Cannot interpret %s as CCYYMMDD", badDate);
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Cannot interpret %s as CCYYMMDD", badDate);
     }
 
     @Test
@@ -71,11 +71,11 @@ class DateFormatMapperTest {
         var result = new DateFormatMapper().mapToDateTimeType(DateFormat.CCYYMMDDHHMM, "201810312359");
         final var assertResult = assertThat(result).isNotNull();
         assertAll(
-            () -> assertResult.extracting(BaseDateTimeType::getYear).isEqualTo(2018),
-            () -> assertResult.extracting(BaseDateTimeType::getMonth).isEqualTo(9),
-            () -> assertResult.extracting(BaseDateTimeType::getDay).isEqualTo(31),
-            () -> assertResult.extracting(BaseDateTimeType::getHour).isEqualTo(23),
-            () -> assertResult.extracting(BaseDateTimeType::getMinute).isEqualTo(59)
+                () -> assertResult.extracting(BaseDateTimeType::getYear).isEqualTo(2018),
+                () -> assertResult.extracting(BaseDateTimeType::getMonth).isEqualTo(9),
+                () -> assertResult.extracting(BaseDateTimeType::getDay).isEqualTo(31),
+                () -> assertResult.extracting(BaseDateTimeType::getHour).isEqualTo(23),
+                () -> assertResult.extracting(BaseDateTimeType::getMinute).isEqualTo(59)
         );
     }
 
@@ -83,7 +83,7 @@ class DateFormatMapperTest {
     @ValueSource(strings = {"wrong", "1", "12345678901234"})
     void testCCYYMMDDHHMMFailure(String badDate) {
         assertThatThrownBy(() -> new DateFormatMapper().mapToDateTimeType(DateFormat.CCYYMMDDHHMM, badDate))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Cannot interpret %s as CCYYMMDDHHMM", badDate);
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Cannot interpret %s as CCYYMMDDHHMM", badDate);
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/MappingUtilsTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/MappingUtilsTest.java
@@ -9,12 +9,12 @@ class MappingUtilsTest {
     @Test
     void testUnescape() {
         assertThat(MappingUtils.unescape("Unescape?+greengrocer?'s??"))
-            .isEqualTo("Unescape+greengrocer's?");
+                .isEqualTo("Unescape+greengrocer's?");
     }
 
     @Test
     void testUnescapeNull() {
         assertThatThrownBy(() -> MappingUtils.unescape(null))
-            .isExactlyInstanceOf(NullPointerException.class);
+                .isExactlyInstanceOf(NullPointerException.class);
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/OrganizationMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/OrganizationMapperTest.java
@@ -15,7 +15,7 @@ class OrganizationMapperTest {
         final Message message = new Message(new ArrayList<>());
 
         assertThat(new OrganizationMapper().mapToPerformingOrganization(message))
-            .isExactlyInstanceOf(Organization.class);
+                .isExactlyInstanceOf(Organization.class);
     }
 
     @Test
@@ -23,7 +23,7 @@ class OrganizationMapperTest {
         final Message message = new Message(new ArrayList<>());
 
         assertThat(new OrganizationMapper().mapToRequestingOrganization(message))
-            .isExactlyInstanceOf(Organization.class);
+                .isExactlyInstanceOf(Organization.class);
     }
 
     @Test
@@ -31,6 +31,6 @@ class OrganizationMapperTest {
         final Message message = new Message(new ArrayList<>());
 
         assertThat(new OrganizationMapper().mapToSpecimenCollectingOrganization(message))
-            .isExactlyInstanceOf(Organization.class);
+                .isExactlyInstanceOf(Organization.class);
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PathologyRecordMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PathologyRecordMapperTest.java
@@ -53,7 +53,7 @@ class PathologyRecordMapperTest {
         var mockPractitioner = mock(Practitioner.class);
 
         when(practitionerMapper.mapRequester(message))
-            .thenReturn(Optional.of(mockPractitioner));
+                .thenReturn(Optional.of(mockPractitioner));
 
         final var pathologyRecord = pathologyRecordMapper.mapToPathologyRecord(message);
 
@@ -90,12 +90,12 @@ class PathologyRecordMapperTest {
         final var mockSpecimen2 = mock(Specimen.class);
         reset(specimenMapper);
         when(specimenMapper.mapToSpecimens(eq(message), any(Patient.class)))
-            .thenReturn(List.of(mockSpecimen1, mockSpecimen2));
+                .thenReturn(List.of(mockSpecimen1, mockSpecimen2));
 
         final var pathologyRecord = pathologyRecordMapper.mapToPathologyRecord(message);
 
         assertThat(pathologyRecord.getSpecimens())
-            .hasSize(2)
-            .contains(mockSpecimen1, mockSpecimen2);
+                .hasSize(2)
+                .contains(mockSpecimen1, mockSpecimen2);
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PatientMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PatientMapperTest.java
@@ -69,8 +69,8 @@ class PatientMapperTest {
     @Test
     void testMapMessageToPatientThrowsExceptionWhenServiceReportDetailsAreNull() {
         assertThatThrownBy(() -> patientMapper.mapToPatient(message))
-            .isInstanceOf(FhirValidationException.class)
-            .hasMessage("Unable to map message to patient details");
+                .isInstanceOf(FhirValidationException.class)
+                .hasMessage("Unable to map message to patient details");
     }
 
     @Test
@@ -78,8 +78,8 @@ class PatientMapperTest {
         when(message.getServiceReportDetails()).thenReturn(serviceReportDetails);
 
         assertThatThrownBy(() -> patientMapper.mapToPatient(message))
-            .isInstanceOf(FhirValidationException.class)
-            .hasMessage("Unable to map message to patient details");
+                .isInstanceOf(FhirValidationException.class)
+                .hasMessage("Unable to map message to patient details");
     }
 
     @Test
@@ -88,8 +88,8 @@ class PatientMapperTest {
         when(serviceReportDetails.getSubject()).thenReturn(investigationSubject);
 
         assertThatThrownBy(() -> patientMapper.mapToPatient(message))
-            .isInstanceOf(FhirValidationException.class)
-            .hasMessage("Unable to map message to patient details");
+                .isInstanceOf(FhirValidationException.class)
+                .hasMessage("Unable to map message to patient details");
     }
 
     @Test
@@ -100,17 +100,17 @@ class PatientMapperTest {
         when(uuidGenerator.generateUUID()).thenReturn(UUID);
 
         final PersonName personName = PersonName.builder()
-            .title(TITLE)
-            .firstForename(FIRST_FORENAME)
-            .secondForename(SECOND_FORENAME)
-            .surname(SURNAME)
-            .nhsNumber(NHS_NUMBER)
-            .build();
+                .title(TITLE)
+                .firstForename(FIRST_FORENAME)
+                .secondForename(SECOND_FORENAME)
+                .surname(SURNAME)
+                .nhsNumber(NHS_NUMBER)
+                .build();
         when(patientDetails.getName()).thenReturn(personName);
 
         final Optional<PersonSex> personSex = Optional.of(PersonSex.builder()
-            .gender(Gender.FEMALE)
-            .build());
+                .gender(Gender.FEMALE)
+                .build());
         when(patientDetails.getSex()).thenReturn(personSex);
 
         stubDateOfBirth(BIRTH_DATE_FULL, DateFormat.CCYYMMDD);
@@ -121,37 +121,38 @@ class PatientMapperTest {
         final Patient patient = patientMapper.mapToPatient(message);
 
         assertAll("patient",
-            () -> assertThat(patient).isNotNull(),
+                () -> assertThat(patient).isNotNull(),
 
-            () -> assertThat(patient.getIdentifier()).hasSize(1).first()
-                .satisfies(identifier -> assertAll(
-                    () -> assertThat(identifier.getValue()).isEqualTo(NHS_NUMBER),
-                    () -> assertThat(identifier.getSystem()).isEqualTo(PatientMapper.NHS_NUMBER_SYSTEM))),
+                () -> assertThat(patient.getIdentifier()).hasSize(1).first()
+                        .satisfies(identifier -> assertAll(
+                                () -> assertThat(identifier.getValue()).isEqualTo(NHS_NUMBER),
+                                () -> assertThat(identifier.getSystem()).isEqualTo(PatientMapper.NHS_NUMBER_SYSTEM))),
 
-            () -> assertThat(patient.getName()).hasSize(1).first()
-                .satisfies(name -> assertAll(
-                    () -> assertThat(name.getPrefixAsSingleString()).isEqualTo(TITLE),
-                    () -> assertThat(name.getGivenAsSingleString()).isEqualTo(FIRST_FORENAME + " " + SECOND_FORENAME),
-                    () -> assertThat(name.getFamily()).isEqualTo(SURNAME))),
+                () -> assertThat(patient.getName()).hasSize(1).first()
+                        .satisfies(name -> assertAll(
+                                () -> assertThat(name.getPrefixAsSingleString()).isEqualTo(TITLE),
+                                () -> assertThat(name.getGivenAsSingleString())
+                                        .isEqualTo(FIRST_FORENAME + " " + SECOND_FORENAME),
+                                () -> assertThat(name.getFamily()).isEqualTo(SURNAME))),
 
-            () -> assertThat(patient.getGender()).isEqualTo(Enumerations.AdministrativeGender.FEMALE),
+                () -> assertThat(patient.getGender()).isEqualTo(Enumerations.AdministrativeGender.FEMALE),
 
-            () -> {
-                final Date birthDate = Date.from(LOCAL_DATE_FULL.atStartOfDay()
-                    .atZone(ZoneId.systemDefault()).toInstant());
-                assertThat(patient.getBirthDate()).isEqualTo(birthDate);
-            },
+                () -> {
+                    final Date birthDate = Date.from(LOCAL_DATE_FULL.atStartOfDay()
+                            .atZone(ZoneId.systemDefault()).toInstant());
+                    assertThat(patient.getBirthDate()).isEqualTo(birthDate);
+                },
 
-            () -> assertThat(patient.getAddress()).hasSize(1).first()
-                .satisfies(address -> assertAll(
-                    () -> {
-                        final List<StringType> lines = List.of(new StringType(ADDRESS_LINE_1),
-                            new StringType(ADDRESS_LINE_2), new StringType(ADDRESS_LINE_3),
-                            new StringType(ADDRESS_LINE_4), new StringType(ADDRESS_LINE_5));
+                () -> assertThat(patient.getAddress()).hasSize(1).first()
+                        .satisfies(address -> assertAll(
+                                () -> {
+                                    final List<StringType> lines = List.of(new StringType(ADDRESS_LINE_1),
+                                            new StringType(ADDRESS_LINE_2), new StringType(ADDRESS_LINE_3),
+                                            new StringType(ADDRESS_LINE_4), new StringType(ADDRESS_LINE_5));
 
-                        assertThat(address.getLine()).usingRecursiveComparison().isEqualTo(lines);
-                    },
-                    () -> assertThat(address.getPostalCode()).isEqualTo(POSTCODE)))
+                                    assertThat(address.getLine()).usingRecursiveComparison().isEqualTo(lines);
+                                },
+                                () -> assertThat(address.getPostalCode()).isEqualTo(POSTCODE)))
         );
     }
 
@@ -163,21 +164,21 @@ class PatientMapperTest {
         when(uuidGenerator.generateUUID()).thenReturn(UUID);
 
         final PersonName personName = PersonName.builder()
-            .title(TITLE)
-            .secondForename(SECOND_FORENAME)
-            .surname(SURNAME)
-            .build();
+                .title(TITLE)
+                .secondForename(SECOND_FORENAME)
+                .surname(SURNAME)
+                .build();
         when(patientDetails.getName()).thenReturn(personName);
 
         final Patient patient = patientMapper.mapToPatient(message);
 
         assertAll("patient",
-            () -> assertThat(patient).isNotNull(),
-            () -> assertThat(patient.getName()).hasSize(1).first()
-                .satisfies(name -> assertAll(
-                    () -> assertThat(name.getPrefixAsSingleString()).isEqualTo(TITLE),
-                    () -> assertThat(name.getGivenAsSingleString()).isEmpty(),
-                    () -> assertThat(name.getFamily()).isEqualTo(SURNAME))));
+                () -> assertThat(patient).isNotNull(),
+                () -> assertThat(patient.getName()).hasSize(1).first()
+                        .satisfies(name -> assertAll(
+                                () -> assertThat(name.getPrefixAsSingleString()).isEqualTo(TITLE),
+                                () -> assertThat(name.getGivenAsSingleString()).isEmpty(),
+                                () -> assertThat(name.getFamily()).isEqualTo(SURNAME))));
     }
 
     @Test
@@ -188,21 +189,21 @@ class PatientMapperTest {
         when(uuidGenerator.generateUUID()).thenReturn(UUID);
 
         final PersonName personName = PersonName.builder()
-            .title(TITLE)
-            .firstForename(FIRST_FORENAME)
-            .surname(SURNAME)
-            .build();
+                .title(TITLE)
+                .firstForename(FIRST_FORENAME)
+                .surname(SURNAME)
+                .build();
         when(patientDetails.getName()).thenReturn(personName);
 
         final Patient patient = patientMapper.mapToPatient(message);
 
         assertAll("patient",
-            () -> assertThat(patient).isNotNull(),
-            () -> assertThat(patient.getName()).hasSize(1).first()
-                .satisfies(name -> assertAll(
-                    () -> assertThat(name.getPrefixAsSingleString()).isEqualTo(TITLE),
-                    () -> assertThat(name.getGivenAsSingleString()).isEqualTo(FIRST_FORENAME),
-                    () -> assertThat(name.getFamily()).isEqualTo(SURNAME))));
+                () -> assertThat(patient).isNotNull(),
+                () -> assertThat(patient.getName()).hasSize(1).first()
+                        .satisfies(name -> assertAll(
+                                () -> assertThat(name.getPrefixAsSingleString()).isEqualTo(TITLE),
+                                () -> assertThat(name.getGivenAsSingleString()).isEqualTo(FIRST_FORENAME),
+                                () -> assertThat(name.getFamily()).isEqualTo(SURNAME))));
     }
 
     @Test
@@ -215,11 +216,11 @@ class PatientMapperTest {
         final Patient patient = patientMapper.mapToPatient(message);
 
         assertAll("patient",
-            () -> assertThat(patient).isNotNull(),
-            () -> assertThat(patient.getIdentifier()).isEmpty(),
-            () -> assertThat(patient.getName()).isEmpty(),
-            () -> assertThat(patient.getGender()).isNull(),
-            () -> assertThat(patient.getBirthDate()).isNull());
+                () -> assertThat(patient).isNotNull(),
+                () -> assertThat(patient.getIdentifier()).isEmpty(),
+                () -> assertThat(patient.getName()).isEmpty(),
+                () -> assertThat(patient.getGender()).isNull(),
+                () -> assertThat(patient.getBirthDate()).isNull());
     }
 
     @Test
@@ -234,16 +235,16 @@ class PatientMapperTest {
         final Patient patient = patientMapper.mapToPatient(message);
 
         assertAll("patient",
-            () -> assertThat(patient).isNotNull(),
-            () -> assertThat(patient.getIdentifier()).isEmpty(),
-            () -> assertThat(patient.getName()).isEmpty(),
-            () -> assertThat(patient.getGender()).isNull(),
+                () -> assertThat(patient).isNotNull(),
+                () -> assertThat(patient.getIdentifier()).isEmpty(),
+                () -> assertThat(patient.getName()).isEmpty(),
+                () -> assertThat(patient.getGender()).isNull(),
 
-            () -> {
-                final Date birthDate = Date.from(LOCAL_DATE_FOR_YEAR_ONLY.atStartOfDay()
-                    .atZone(ZoneId.systemDefault()).toInstant());
-                assertThat(patient.getBirthDate()).isEqualTo(birthDate);
-            });
+                () -> {
+                    final Date birthDate = Date.from(LOCAL_DATE_FOR_YEAR_ONLY.atStartOfDay()
+                            .atZone(ZoneId.systemDefault()).toInstant());
+                    assertThat(patient.getBirthDate()).isEqualTo(birthDate);
+                });
     }
 
     @Test
@@ -258,16 +259,16 @@ class PatientMapperTest {
         final Patient patient = patientMapper.mapToPatient(message);
 
         assertAll("patient",
-            () -> assertThat(patient).isNotNull(),
-            () -> assertThat(patient.getIdentifier()).isEmpty(),
-            () -> assertThat(patient.getName()).isEmpty(),
-            () -> assertThat(patient.getGender()).isNull(),
+                () -> assertThat(patient).isNotNull(),
+                () -> assertThat(patient.getIdentifier()).isEmpty(),
+                () -> assertThat(patient.getName()).isEmpty(),
+                () -> assertThat(patient.getGender()).isNull(),
 
-            () -> {
-                final Date birthDate = Date.from(LOCAL_DATE_FOR_YEAR_AND_MONTH.atStartOfDay()
-                    .atZone(ZoneId.systemDefault()).toInstant());
-                assertThat(patient.getBirthDate()).isEqualTo(birthDate);
-            });
+                () -> {
+                    final Date birthDate = Date.from(LOCAL_DATE_FOR_YEAR_AND_MONTH.atStartOfDay()
+                            .atZone(ZoneId.systemDefault()).toInstant());
+                    assertThat(patient.getBirthDate()).isEqualTo(birthDate);
+                });
     }
 
     @Test
@@ -278,25 +279,26 @@ class PatientMapperTest {
         when(uuidGenerator.generateUUID()).thenReturn(UUID);
 
         final PersonName personName = PersonName.builder()
-            .title(TITLE)
-            .firstForename(FIRST_FORENAME)
-            .secondForename(SECOND_FORENAME)
-            .surname(SURNAME)
-            .nhsNumber(NHS_NUMBER)
-            .build();
+                .title(TITLE)
+                .firstForename(FIRST_FORENAME)
+                .secondForename(SECOND_FORENAME)
+                .surname(SURNAME)
+                .nhsNumber(NHS_NUMBER)
+                .build();
         when(patientDetails.getName()).thenReturn(personName);
 
         final Patient patient = patientMapper.mapToPatient(message);
 
         assertAll("patient",
-            () -> assertThat(patient).isNotNull(),
-            () -> assertThat(patient.getName()).hasSize(1).first()
-                .satisfies(name -> assertAll(
-                    () -> assertThat(name.getPrefixAsSingleString()).isEqualTo(TITLE),
-                    () -> assertThat(name.getGivenAsSingleString()).isEqualTo(FIRST_FORENAME + " " + SECOND_FORENAME),
-                    () -> assertThat(name.getFamily()).isEqualTo(SURNAME))),
+                () -> assertThat(patient).isNotNull(),
+                () -> assertThat(patient.getName()).hasSize(1).first()
+                        .satisfies(name -> assertAll(
+                                () -> assertThat(name.getPrefixAsSingleString()).isEqualTo(TITLE),
+                                () -> assertThat(name.getGivenAsSingleString())
+                                        .isEqualTo(FIRST_FORENAME + " " + SECOND_FORENAME),
+                                () -> assertThat(name.getFamily()).isEqualTo(SURNAME))),
 
-            () -> assertThat(patient.getAddress()).isEmpty());
+                () -> assertThat(patient.getAddress()).isEmpty());
     }
 
     @Test
@@ -307,10 +309,10 @@ class PatientMapperTest {
         when(uuidGenerator.generateUUID()).thenReturn(UUID);
 
         final PersonName personName = PersonName.builder()
-            .title(TITLE)
-            .firstForename(FIRST_FORENAME)
-            .surname(SURNAME)
-            .build();
+                .title(TITLE)
+                .firstForename(FIRST_FORENAME)
+                .surname(SURNAME)
+                .build();
         when(patientDetails.getName()).thenReturn(personName);
 
         stubAddress(null);
@@ -318,26 +320,26 @@ class PatientMapperTest {
         final Patient patient = patientMapper.mapToPatient(message);
 
         assertAll("patient",
-            () -> assertThat(patient).isNotNull(),
+                () -> assertThat(patient).isNotNull(),
 
-            () -> assertThat(patient.getName()).hasSize(1).first()
-                .satisfies(name -> assertAll(
-                    () -> assertThat(name.getPrefixAsSingleString()).isEqualTo(TITLE),
-                    () -> assertThat(name.getGivenAsSingleString()).isEqualTo(FIRST_FORENAME),
-                    () -> assertThat(name.getFamily()).isEqualTo(SURNAME))),
+                () -> assertThat(patient.getName()).hasSize(1).first()
+                        .satisfies(name -> assertAll(
+                                () -> assertThat(name.getPrefixAsSingleString()).isEqualTo(TITLE),
+                                () -> assertThat(name.getGivenAsSingleString()).isEqualTo(FIRST_FORENAME),
+                                () -> assertThat(name.getFamily()).isEqualTo(SURNAME))),
 
-            () -> assertThat(patient.getAddress()).hasSize(1).first()
-                .satisfies(address -> assertAll(
-                    () -> assertThat(address.getLine()).isEmpty(),
-                    () -> assertThat(address.getPostalCode()).isEqualTo(POSTCODE)))
+                () -> assertThat(patient.getAddress()).hasSize(1).first()
+                        .satisfies(address -> assertAll(
+                                () -> assertThat(address.getLine()).isEmpty(),
+                                () -> assertThat(address.getPostalCode()).isEqualTo(POSTCODE)))
         );
     }
 
     private void stubDateOfBirth(final String dateOfBirth, final DateFormat dateFormat) {
         final Optional<PersonDateOfBirth> personDateOfBirth = Optional.of(PersonDateOfBirth.builder()
-            .dateOfBirth(dateOfBirth)
-            .dateFormat(dateFormat)
-            .build());
+                .dateOfBirth(dateOfBirth)
+                .dateFormat(dateFormat)
+                .build());
         when(patientDetails.getDateOfBirth()).thenReturn(personDateOfBirth);
     }
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PractitionerMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/PractitionerMapperTest.java
@@ -1,14 +1,5 @@
 package uk.nhs.digital.nhsconnect.lab.results.translator.mapper;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
 import org.hl7.fhir.dstu3.model.HumanName;
 import org.hl7.fhir.dstu3.model.Practitioner;
 import org.junit.jupiter.api.Test;
@@ -16,12 +7,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Message;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.PerformerNameAndAddress;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.RequesterNameAndAddress;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.segmentgroup.InvolvedParty;
 import uk.nhs.digital.nhsconnect.lab.results.utils.UUIDGenerator;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PractitionerMapperTest {
@@ -62,18 +61,18 @@ class PractitionerMapperTest {
         Practitioner practitioner = result.get();
 
         assertAll(
-            () -> assertThat(practitioner.getName())
-                    .hasSize(1)
-                    .first()
-                    .extracting(HumanName::getText)
-                    .isEqualTo("Alan Turing"),
-            () -> assertThat(practitioner.getIdentifier())
-                    .hasSize(1)
-                    .first()
-                    .satisfies(identifier -> assertAll(
-                        () -> assertThat(identifier.getValue()).isEqualTo("Identifier"),
-                        () -> assertThat(identifier.getSystem()).isEqualTo("https://fhir.nhs.uk/Id/sds-user-id")
-                    ))
+                () -> assertThat(practitioner.getName())
+                        .hasSize(1)
+                        .first()
+                        .extracting(HumanName::getText)
+                        .isEqualTo("Alan Turing"),
+                () -> assertThat(practitioner.getIdentifier())
+                        .hasSize(1)
+                        .first()
+                        .satisfies(identifier -> assertAll(
+                                () -> assertThat(identifier.getValue()).isEqualTo("Identifier"),
+                                () -> assertThat(identifier.getSystem()).isEqualTo("https://fhir.nhs.uk/Id/sds-user-id")
+                        ))
         );
     }
 
@@ -111,18 +110,18 @@ class PractitionerMapperTest {
         Practitioner practitioner = result.get();
 
         assertAll(
-            () -> assertThat(practitioner.getName())
-                .hasSize(1)
-                .first()
-                .extracting(HumanName::getText)
-                .isEqualTo("Jane Doe"),
-            () -> assertThat(practitioner.getIdentifier())
-                .hasSize(1)
-                .first()
-                .satisfies(identifier -> assertAll(
-                    () -> assertThat(identifier.getValue()).isEqualTo("Identifier"),
-                    () -> assertThat(identifier.getSystem()).isEqualTo("https://fhir.nhs.uk/Id/sds-user-id")
-                ))
+                () -> assertThat(practitioner.getName())
+                        .hasSize(1)
+                        .first()
+                        .extracting(HumanName::getText)
+                        .isEqualTo("Jane Doe"),
+                () -> assertThat(practitioner.getIdentifier())
+                        .hasSize(1)
+                        .first()
+                        .satisfies(identifier -> assertAll(
+                                () -> assertThat(identifier.getValue()).isEqualTo("Identifier"),
+                                () -> assertThat(identifier.getSystem()).isEqualTo("https://fhir.nhs.uk/Id/sds-user-id")
+                        ))
         );
 
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/ProcedureRequestMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/ProcedureRequestMapperTest.java
@@ -15,6 +15,6 @@ class ProcedureRequestMapperTest {
         final Message message = new Message(new ArrayList<>());
 
         assertThat(new ProcedureRequestMapper().mapToProcedureRequest(message))
-            .isExactlyInstanceOf(ProcedureRequest.class);
+                .isExactlyInstanceOf(ProcedureRequest.class);
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/SpecimenMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/SpecimenMapperTest.java
@@ -56,182 +56,182 @@ class SpecimenMapperTest {
     @Test
     void testMapToSpecimensMissingRequiredSegments() {
         final Message message = new Message(List.of(
-            "S02+02", // ServiceReportDetails
-            "S06+06", // InvestigationSubject
-            "S16+16"  // SpecimenDetails
+                "S02+02", // ServiceReportDetails
+                "S06+06", // InvestigationSubject
+                "S16+16"  // SpecimenDetails
         ));
 
         assertThatThrownBy(() -> specimenMapper.mapToSpecimens(message, null))
-            .isExactlyInstanceOf(MissingSegmentException.class)
-            .hasMessageStartingWith("EDIFACT section is missing segment");
+                .isExactlyInstanceOf(MissingSegmentException.class)
+                .hasMessageStartingWith("EDIFACT section is missing segment");
     }
 
     @Test
     void testMapToSpecimensOnlyRequiredSegmentCharacteristicType() {
         when(uuidGenerator.generateUUID()).thenReturn("test-uuid");
         final Message message = new Message(List.of(
-            "S02+02", // ServiceReportDetails
-            "S06+06", // InvestigationSubject
-            "S16+16", // SpecimenDetails
-            "SPC+TSP+:::Specimen type", // SpecimenCharacteristicType
-            "S16+16", // SpecimenDetails
+                "S02+02", // ServiceReportDetails
+                "S06+06", // InvestigationSubject
+                "S16+16", // SpecimenDetails
+                "SPC+TSP+:::Specimen type", // SpecimenCharacteristicType
+                "S16+16", // SpecimenDetails
 
-            "SPC+TSP+:::Specimen type" // SpecimenCharacteristicType
+                "SPC+TSP+:::Specimen type" // SpecimenCharacteristicType
         ));
 
         final var specimens = specimenMapper.mapToSpecimens(message, null);
 
         assertThat(specimens).hasSize(2)
-            .allSatisfy(specimen -> assertThat(specimen.getType().getCoding())
-                .hasSize(1)
-                .map(Coding::getDisplay)
-                .allMatch("Specimen type"::equals))
-            .allSatisfy(specimen -> assertThat(specimen.getId()).isEqualTo("test-uuid"));
+                .allSatisfy(specimen -> assertThat(specimen.getType().getCoding())
+                        .hasSize(1)
+                        .map(Coding::getDisplay)
+                        .allMatch("Specimen type"::equals))
+                .allSatisfy(specimen -> assertThat(specimen.getId()).isEqualTo("test-uuid"));
     }
 
     @Test
     void testMapToSpecimensServiceRequesterReference() {
         final Message message = new Message(List.of(
-            "S02+02", // ServiceReportDetails
-            "S06+06", // InvestigationSubject
-            "S16+16", // SpecimenDetails
-            "SPC+TSP+:::Required", // SpecimenCharacteristicType
+                "S02+02", // ServiceReportDetails
+                "S06+06", // InvestigationSubject
+                "S16+16", // SpecimenDetails
+                "SPC+TSP+:::Required", // SpecimenCharacteristicType
 
-            "RFF+RTI:Requester" // Reference - SPECIMEN_BY_REQUESTER
+                "RFF+RTI:Requester" // Reference - SPECIMEN_BY_REQUESTER
         ));
 
         final var specimens = specimenMapper.mapToSpecimens(message, null);
 
         assertThat(specimens).hasSize(1)
-            .first()
-            .satisfies(specimen -> assertThat(specimen.getIdentifier()).hasSize(1)
                 .first()
-                .extracting(Identifier::getValue)
-                .isEqualTo("Requester"));
+                .satisfies(specimen -> assertThat(specimen.getIdentifier()).hasSize(1)
+                        .first()
+                        .extracting(Identifier::getValue)
+                        .isEqualTo("Requester"));
     }
 
     @Test
     void testMapToSpecimensServiceProviderReference() {
         final Message message = new Message(List.of(
-            "S02+02", // ServiceReportDetails
-            "S06+06", // InvestigationSubject
-            "S16+16", // SpecimenDetails
-            "SPC+TSP+:::Required", // SpecimenCharacteristicType
+                "S02+02", // ServiceReportDetails
+                "S06+06", // InvestigationSubject
+                "S16+16", // SpecimenDetails
+                "SPC+TSP+:::Required", // SpecimenCharacteristicType
 
-            "RFF+STI:Provider" // Reference - SPECIMEN_BY_PROVIDER
+                "RFF+STI:Provider" // Reference - SPECIMEN_BY_PROVIDER
         ));
 
         final var specimens = specimenMapper.mapToSpecimens(message, null);
 
         assertThat(specimens).hasSize(1)
-            .first()
-            .satisfies(specimen -> assertThat(specimen.getAccessionIdentifier())
-                .extracting(Identifier::getValue)
-                .isEqualTo("Provider"));
+                .first()
+                .satisfies(specimen -> assertThat(specimen.getAccessionIdentifier())
+                        .extracting(Identifier::getValue)
+                        .isEqualTo("Provider"));
     }
 
     @Test
     void testMapToSpecimensCollectionReceiptDateTime() {
         final var expectedDate = new Date();
         when(dateFormatMapper.mapToDate(any(DateFormat.class), anyString()))
-            .thenReturn(expectedDate);
+                .thenReturn(expectedDate);
 
         final Message message = new Message(List.of(
-            "S02+02", // ServiceReportDetails
-            "S06+06", // InvestigationSubject
-            "S16+16", // SpecimenDetails
-            "SPC+TSP+:::Required", // SpecimenCharacteristicType
+                "S02+02", // ServiceReportDetails
+                "S06+06", // InvestigationSubject
+                "S16+16", // SpecimenDetails
+                "SPC+TSP+:::Required", // SpecimenCharacteristicType
 
-            "DTM+SRI:date:203" // SpecimenCollectionReceiptDateTime
+                "DTM+SRI:date:203" // SpecimenCollectionReceiptDateTime
         ));
 
         final var specimens = specimenMapper.mapToSpecimens(message, null);
 
         assertThat(specimens).hasSize(1)
-            .first()
-            .satisfies(specimen -> assertThat(specimen.getReceivedTime()).isEqualTo(expectedDate));
+                .first()
+                .satisfies(specimen -> assertThat(specimen.getReceivedTime()).isEqualTo(expectedDate));
     }
 
     @Test
     void testMapToSpecimensCollectionDateTime() {
         final var expectedDate = mock(DateTimeType.class);
         when(dateFormatMapper.mapToDateTimeType(any(DateFormat.class), anyString()))
-            .thenReturn(expectedDate);
+                .thenReturn(expectedDate);
 
         final Message message = new Message(List.of(
-            "S02+02", // ServiceReportDetails
-            "S06+06", // InvestigationSubject
-            "S16+16", // SpecimenDetails
-            "SPC+TSP+:::Required", // SpecimenCharacteristicType
+                "S02+02", // ServiceReportDetails
+                "S06+06", // InvestigationSubject
+                "S16+16", // SpecimenDetails
+                "SPC+TSP+:::Required", // SpecimenCharacteristicType
 
-            "DTM+SCO:date:203" // SpecimenCollectionDateTime
+                "DTM+SCO:date:203" // SpecimenCollectionDateTime
         ));
 
         final var specimens = specimenMapper.mapToSpecimens(message, null);
 
         assertThat(specimens).hasSize(1)
-            .first()
-            .satisfies(specimen -> assertThat(specimen.getCollection().getCollected()).isEqualTo(expectedDate));
+                .first()
+                .satisfies(specimen -> assertThat(specimen.getCollection().getCollected()).isEqualTo(expectedDate));
     }
 
     @Test
     void testMapToSpecimensQuantityAndUnitOfMeasure() {
         final Message message = new Message(List.of(
-            "S02+02", // ServiceReportDetails
-            "S06+06", // InvestigationSubject
-            "S16+16", // SpecimenDetails
-            "SPC+TSP+:::Required", // SpecimenCharacteristicType
+                "S02+02", // ServiceReportDetails
+                "S06+06", // InvestigationSubject
+                "S16+16", // SpecimenDetails
+                "SPC+TSP+:::Required", // SpecimenCharacteristicType
 
-            "QTY+SVO:1+:::unit" // SpecimenQuantity
+                "QTY+SVO:1+:::unit" // SpecimenQuantity
         ));
 
         final var specimens = specimenMapper.mapToSpecimens(message, null);
 
         assertThat(specimens).hasSize(1)
-            .first()
-            .satisfies(specimen -> assertAll(
-                () -> assertThat(specimen.getCollection().getQuantity().getValue()).isEqualTo(BigDecimal.ONE),
-                () -> assertThat(specimen.getCollection().getQuantity().getUnit()).isEqualTo("unit")
-            ));
+                .first()
+                .satisfies(specimen -> assertAll(
+                        () -> assertThat(specimen.getCollection().getQuantity().getValue()).isEqualTo(BigDecimal.ONE),
+                        () -> assertThat(specimen.getCollection().getQuantity().getUnit()).isEqualTo("unit")
+                ));
     }
 
     @Test
     void testMapToSpecimensFreeTexts() {
         final Message message = new Message(List.of(
-            "S02+02", // ServiceReportDetails
-            "S06+06", // InvestigationSubject
-            "S16+16", // SpecimenDetails
-            "SPC+TSP+:::Required", // SpecimenCharacteristicType
+                "S02+02", // ServiceReportDetails
+                "S06+06", // InvestigationSubject
+                "S16+16", // SpecimenDetails
+                "SPC+TSP+:::Required", // SpecimenCharacteristicType
 
-            "FTX+SPC+++item 1 part 1:item 1 part 2", // FreeTextSegment
-            "FTX+SPC+++item 2 part 1:item 2 part 2"  // FreeTextSegment
+                "FTX+SPC+++item 1 part 1:item 1 part 2", // FreeTextSegment
+                "FTX+SPC+++item 2 part 1:item 2 part 2"  // FreeTextSegment
         ));
 
         final var specimens = specimenMapper.mapToSpecimens(message, null);
 
         assertThat(specimens).hasSize(1)
-            .first()
-            .satisfies(specimen -> assertThat(specimen.getNote())
-                .extracting(Annotation::getText)
-                .contains("item 1 part 1", "item 1 part 2", "item 2 part 1", "item 2 part 2"));
+                .first()
+                .satisfies(specimen -> assertThat(specimen.getNote())
+                        .extracting(Annotation::getText)
+                        .contains("item 1 part 1", "item 1 part 2", "item 2 part 1", "item 2 part 2"));
     }
 
     @Test
     void testMapToSpecimensPatientReference() {
         final Message message = new Message(List.of(
-            "S02+02", // ServiceReportDetails
-            "S06+06", // InvestigationSubject
-            "S16+16", // SpecimenDetails
-            "SPC+TSP+:::Required" // SpecimenCharacteristicType
+                "S02+02", // ServiceReportDetails
+                "S06+06", // InvestigationSubject
+                "S16+16", // SpecimenDetails
+                "SPC+TSP+:::Required" // SpecimenCharacteristicType
         ));
         when(fullUrlGenerator.generate(any(Patient.class))).thenReturn("patient-full-url");
 
         final var specimens = specimenMapper.mapToSpecimens(message, mock(Patient.class));
 
         assertThat(specimens).hasSize(1)
-            .first()
-            .satisfies(specimen -> assertThat(specimen.getSubject())
-                .extracting(Reference::getReference)
-                .isEqualTo("patient-full-url"));
+                .first()
+                .satisfies(specimen -> assertThat(specimen.getSubject())
+                        .extracting(Reference::getReference)
+                        .isEqualTo("patient-full-url"));
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/utils/JmsReaderTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/utils/JmsReaderTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
 import javax.jms.Message;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/utils/PemFormatterTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/utils/PemFormatterTest.java
@@ -11,13 +11,13 @@ class PemFormatterTest {
     @Test
     void when_certHasExtraWhitespace_expect_itIsTrimmed() {
         final String withWhitespace = " -----BEGIN CERTIFICATE-----\n "
-            + "    \t  MIIFXzCCA0egAwIBAgIJALRbCSor9bEbMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV \n"
-            + "  \n\n    W/JNIRmhLoeFNGNh8HvhI2PwOCsFiqT1rrCaUtusTyH0Ggs=\n"
-            + "   \r   -----END CERTIFICATE-----";
+                + "    \t  MIIFXzCCA0egAwIBAgIJALRbCSor9bEbMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV \n"
+                + "  \n\n    W/JNIRmhLoeFNGNh8HvhI2PwOCsFiqT1rrCaUtusTyH0Ggs=\n"
+                + "   \r   -----END CERTIFICATE-----";
         final String trimmed = "-----BEGIN CERTIFICATE-----\n"
-            + "MIIFXzCCA0egAwIBAgIJALRbCSor9bEbMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\n"
-            + "W/JNIRmhLoeFNGNh8HvhI2PwOCsFiqT1rrCaUtusTyH0Ggs=\n"
-            + "-----END CERTIFICATE-----";
+                + "MIIFXzCCA0egAwIBAgIJALRbCSor9bEbMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\n"
+                + "W/JNIRmhLoeFNGNh8HvhI2PwOCsFiqT1rrCaUtusTyH0Ggs=\n"
+                + "-----END CERTIFICATE-----";
         final String formatted = PemFormatter.format(withWhitespace);
         assertThat(formatted).isEqualTo(trimmed);
     }
@@ -25,13 +25,13 @@ class PemFormatterTest {
     @Test
     void when_certHasNoNewlines_expect_itIsReformatted() {
         final String withoutNewlines = "-----BEGIN RSA PRIVATE KEY-----"
-            + " MIIJKQIBAAKCAgEA0x7V2cpEuXbLxb4TFigeN6e/TViXx4B9LMuHwwENX1P5V3O5"
-            + " M0d/fLCFruu5dU3PWKoU2rTzUkflj5XOzu2xAftYi3KDMzRR2sByxjjxb/qMIybG"
-            + " -----END RSA PRIVATE KEY-----";
+                + " MIIJKQIBAAKCAgEA0x7V2cpEuXbLxb4TFigeN6e/TViXx4B9LMuHwwENX1P5V3O5"
+                + " M0d/fLCFruu5dU3PWKoU2rTzUkflj5XOzu2xAftYi3KDMzRR2sByxjjxb/qMIybG"
+                + " -----END RSA PRIVATE KEY-----";
         final String trimmed = "-----BEGIN RSA PRIVATE KEY-----\n"
-            + "MIIJKQIBAAKCAgEA0x7V2cpEuXbLxb4TFigeN6e/TViXx4B9LMuHwwENX1P5V3O5\n"
-            + "M0d/fLCFruu5dU3PWKoU2rTzUkflj5XOzu2xAftYi3KDMzRR2sByxjjxb/qMIybG\n"
-            + "-----END RSA PRIVATE KEY-----";
+                + "MIIJKQIBAAKCAgEA0x7V2cpEuXbLxb4TFigeN6e/TViXx4B9LMuHwwENX1P5V3O5\n"
+                + "M0d/fLCFruu5dU3PWKoU2rTzUkflj5XOzu2xAftYi3KDMzRR2sByxjjxb/qMIybG\n"
+                + "-----END RSA PRIVATE KEY-----";
         final String formatted = PemFormatter.format(withoutNewlines);
         assertThat(formatted).isEqualTo(trimmed);
     }
@@ -39,9 +39,9 @@ class PemFormatterTest {
     @Test
     void when_certUsesDifferentHeaderAndFormattedCorrectly_expect_itIsNotModified() {
         final String pem = "-----BEGIN PRIVATE KEY-----\n"
-            + "MIIJKQIBAAKCAgEA0x7V2cpEuXbLxb4TFigeN6e/TViXx4B9LMuHwwENX1P5V3O5\n"
-            + "M0d/fLCFruu5dU3PWKoU2rTzUkflj5XOzu2xAftYi3KDMzRR2sByxjjxb/qMIybG\n"
-            + "-----END PRIVATE KEY-----";
+                + "MIIJKQIBAAKCAgEA0x7V2cpEuXbLxb4TFigeN6e/TViXx4B9LMuHwwENX1P5V3O5\n"
+                + "M0d/fLCFruu5dU3PWKoU2rTzUkflj5XOzu2xAftYi3KDMzRR2sByxjjxb/qMIybG\n"
+                + "-----END PRIVATE KEY-----";
         final String formatted = PemFormatter.format(pem);
         assertThat(formatted).isEqualTo(pem);
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/utils/ResourceFullUrlGeneratorTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/utils/ResourceFullUrlGeneratorTest.java
@@ -31,8 +31,8 @@ class ResourceFullUrlGeneratorTest {
     @SuppressWarnings("ConstantConditions")
     void testMapToFullUrlNullResource() {
         assertThatThrownBy(() -> fullUrlGenerator.generate(null))
-            .isExactlyInstanceOf(NullPointerException.class)
-            .hasMessage("resource is marked non-null but is null");
+                .isExactlyInstanceOf(NullPointerException.class)
+                .hasMessage("resource is marked non-null but is null");
     }
 
     @Test
@@ -41,8 +41,8 @@ class ResourceFullUrlGeneratorTest {
         when(resource.getId()).thenReturn(null);
 
         assertThatThrownBy(() -> fullUrlGenerator.generate(resource))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("resource.id must be present and non-blank");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("resource.id must be present and non-blank");
     }
 
     @Test
@@ -51,8 +51,8 @@ class ResourceFullUrlGeneratorTest {
         when(resource.getId()).thenReturn("");
 
         assertThatThrownBy(() -> fullUrlGenerator.generate(resource))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("resource.id must be present and non-blank");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("resource.id must be present and non-blank");
     }
 
     @Test
@@ -61,7 +61,7 @@ class ResourceFullUrlGeneratorTest {
         when(resource.getId()).thenReturn("  \t \n ");
 
         assertThatThrownBy(() -> fullUrlGenerator.generate(resource))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("resource.id must be present and non-blank");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("resource.id must be present and non-blank");
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/segments/model/edifact/FreeTextSegmentTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/segments/model/edifact/FreeTextSegmentTest.java
@@ -14,31 +14,31 @@ class FreeTextSegmentTest {
     @Test
     void testGetKey() {
         assertThat(new FreeTextSegment(FreeTextType.CLINICAL_INFO, new String[0]).getKey())
-            .isEqualTo("FTX");
+                .isEqualTo("FTX");
     }
 
     @Test
     void testWrongKey() {
         assertThatThrownBy(() -> FreeTextSegment.fromString("WRONG+CID+++OK"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Can't create FreeTextSegment from WRONG+CID+++OK");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Can't create FreeTextSegment from WRONG+CID+++OK");
     }
 
     @Test
     void testUnknownQualifier() {
         assertThatThrownBy(() -> FreeTextSegment.fromString("FTX+ZZZ+++Eek"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("No free text type for 'ZZZ'");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("No free text type for 'ZZZ'");
     }
 
     @Test
     void testNoTexts() {
         var result = FreeTextSegment.fromString("FTX+CRR+++");
         assertAll(
-            () -> assertThat(result.getTexts()).isEmpty(),
-            () -> assertThatThrownBy(result::validate)
-                .isExactlyInstanceOf(EdifactValidationException.class)
-                .hasMessage("FTX+CRR: At least one free text must be given.")
+                () -> assertThat(result.getTexts()).isEmpty(),
+                () -> assertThatThrownBy(result::validate)
+                        .isExactlyInstanceOf(EdifactValidationException.class)
+                        .hasMessage("FTX+CRR: At least one free text must be given.")
         );
     }
 
@@ -46,8 +46,8 @@ class FreeTextSegmentTest {
     void testOneText() {
         var result = FreeTextSegment.fromString("FTX+RIT+++Okay");
         assertAll(
-            () -> assertThat(result.getTexts()).containsExactly("Okay"),
-            () -> assertThatNoException().isThrownBy(result::validate)
+                () -> assertThat(result.getTexts()).containsExactly("Okay"),
+                () -> assertThatNoException().isThrownBy(result::validate)
         );
     }
 
@@ -55,9 +55,9 @@ class FreeTextSegmentTest {
     @SuppressWarnings("checkstyle:MagicNumber")
     void testFromStringTooManyFreeTexts() {
         assertThatThrownBy(() -> FreeTextSegment.fromString("FTX+RPD+++A" + ":A".repeat(10)))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage(
-                "Can't create FreeTextSegment from FTX+RPD+++A:A:A:A:A:A:A:A:A:A:A because too many free texts");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Can't create FreeTextSegment from FTX+RPD+++A:A:A:A:A:A:A:A:A:A:A "
+                        + "because too many free texts");
     }
 
     @Test
@@ -66,7 +66,7 @@ class FreeTextSegmentTest {
         final var texts = "A".repeat(10).split("");
         final var freeText = new FreeTextSegment(FreeTextType.SERVICE_PROVIDER_COMMENT, texts);
         assertThatThrownBy(freeText::validate)
-            .isExactlyInstanceOf(EdifactValidationException.class)
-            .hasMessage("FTX+SPC: At most 5 free texts may be given.");
+                .isExactlyInstanceOf(EdifactValidationException.class)
+                .hasMessage("FTX+SPC: At most 5 free texts may be given.");
     }
 }


### PR DESCRIPTION
## Description

Starting with IntelliJ defaults:
1. Never use '*' imports (999 threshold)
2. Always wrap if long
3. Binary operation signs on next line

Gradle uses an old version of checkstyle by
default – this is upgraded to 8.41.

A couple of places then still violated checkstyle
because they couldn't be fixed automatically.

## Jira Ticket

https://gpitbjss.atlassian.net/browse/NIAD-1132

## Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [ ] Acceptance Criteria met
- [ ] Commit messages are meaningful
- [ ] Manually tested
- [ ] Self-reviewed your code
- [ ] Code reviewed from two other developers
- [ ] If your pull request depends on any other, please link them in the description
- [ ] main branch is passing/green on CI
- [ ] Add/update any relevant documentation
