### PR TITLE
NIAD-1152: Add the message type to GP Outbound queue items

### DIFF
--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageHeader.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageHeader.java
@@ -4,13 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.EdifactValidationException;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.Split;
 
 /**
- * A specialisation of a segment for the specific use case of a message header
- * takes in specific values required to generate an message header
- * example: UNH+00000003+FHSREG:0:1:FH:FHS001'.
+ * A specialisation of a segment for the specific use case of a message header.
+ * Takes in specific values required to generate an message header.
+ * Example: {@code UNH+00000003+FHSREG:0:1:FH:FHS001'}.
  */
 @Getter
 @Setter
@@ -21,7 +22,10 @@ public class MessageHeader extends Segment {
     public static final String KEY = "UNH";
     public static final long MAX_MESSAGE_SEQUENCE = 99_999_999L;
 
+    private static final int INDEX_MESSAGE_TYPE = 4;
+
     private Long sequenceNumber;
+    private String messageType;
 
     @Override
     public String getKey() {
@@ -37,6 +41,9 @@ public class MessageHeader extends Segment {
             throw new EdifactValidationException(KEY + ": Attribute sequenceNumber must be between 1 and "
                 + MAX_MESSAGE_SEQUENCE);
         }
+        if (StringUtils.isBlank(messageType)) {
+            throw new EdifactValidationException(KEY + ": Attribute messageType is required");
+        }
     }
 
     public static MessageHeader fromString(final String edifactString) {
@@ -44,7 +51,8 @@ public class MessageHeader extends Segment {
             throw new IllegalArgumentException("Can't create " + MessageHeader.class.getSimpleName()
                 + " from " + edifactString);
         }
-        final String[] split = Split.byPlus(edifactString);
-        return new MessageHeader(Long.valueOf(split[1]));
+        final String[] splitByPlus = Split.byPlus(edifactString);
+        final String[] splitByColon = Split.byColon(splitByPlus[2]);
+        return new MessageHeader(Long.valueOf(splitByPlus[1]), splitByColon[INDEX_MESSAGE_TYPE]);
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageHeader.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageHeader.java
@@ -22,6 +22,7 @@ public class MessageHeader extends Segment {
     public static final String KEY = "UNH";
     public static final long MAX_MESSAGE_SEQUENCE = 99_999_999L;
 
+    private static final int INDEX_SEQUENCE_NUMBER = 1;
     private static final int INDEX_MESSAGE_TYPE = 4;
 
     private Long sequenceNumber;
@@ -53,6 +54,6 @@ public class MessageHeader extends Segment {
         }
         final String[] splitByPlus = Split.byPlus(edifactString);
         final String[] splitByColon = Split.byColon(splitByPlus[2]);
-        return new MessageHeader(Long.valueOf(splitByPlus[1]), splitByColon[INDEX_MESSAGE_TYPE]);
+        return new MessageHeader(Long.valueOf(splitByPlus[INDEX_SEQUENCE_NUMBER]), splitByColon[INDEX_MESSAGE_TYPE]);
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/outbound/queue/GpOutboundQueueService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/outbound/queue/GpOutboundQueueService.java
@@ -40,6 +40,8 @@ public class GpOutboundQueueService {
             final TextMessage message = session.createTextMessage(jsonMessage);
             message.setStringProperty(JmsHeaders.CORRELATION_ID, correlationIdService.getCurrentCorrelationId());
             message.setStringProperty(JmsHeaders.CHECKSUM, buildChecksum(processingResult.getMessage()));
+            message.setStringProperty(JmsHeaders.MESSAGE_TYPE,
+                processingResult.getMessage().getMessageHeader().getMessageType());
             return message;
         };
 

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/utils/JmsHeaders.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/utils/JmsHeaders.java
@@ -4,6 +4,7 @@ public final class JmsHeaders {
 
     public static final String CORRELATION_ID = "CorrelationId";
     public static final String CHECKSUM = "Checksum";
+    public static final String MESSAGE_TYPE = "MessageType";
 
     private JmsHeaders() { }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageHeaderTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/model/edifact/MessageHeaderTest.java
@@ -3,64 +3,81 @@ package uk.nhs.digital.nhsconnect.lab.results.model.edifact;
 import org.junit.jupiter.api.Test;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.message.EdifactValidationException;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@SuppressWarnings("checkstyle:MagicNumber")
 class MessageHeaderTest {
-
-    private static final long SEQUENCE_NUMBER = 3L;
 
     @Test
     void testValidateSequenceNumberNullThrowsException() {
-        final MessageHeader messageHeader = new MessageHeader();
+        final var messageHeader = new MessageHeader();
 
-        final EdifactValidationException exception = assertThrows(EdifactValidationException.class,
-                messageHeader::validate);
-
-        assertEquals("UNH: Attribute sequenceNumber is required", exception.getMessage());
+        assertThatThrownBy(messageHeader::validate)
+            .isExactlyInstanceOf(EdifactValidationException.class)
+            .hasMessage("UNH: Attribute sequenceNumber is required");
     }
 
     @Test
     void testValidateSequenceNumberLessThanMinimumValueThrowsException() {
-        final MessageHeader messageHeader = new MessageHeader(0L);
+        final var messageHeader = new MessageHeader(0L, "");
 
-        final EdifactValidationException exception = assertThrows(EdifactValidationException.class,
-                messageHeader::validate);
-
-        assertEquals("UNH: Attribute sequenceNumber must be between 1 and 99999999", exception.getMessage());
+        assertThatThrownBy(messageHeader::validate)
+            .isExactlyInstanceOf(EdifactValidationException.class)
+            .hasMessage("UNH: Attribute sequenceNumber must be between 1 and 99999999");
     }
 
     @Test
     void testValidateSequenceNumberMoreThanMaxValueThrowsException() {
-        final MessageHeader messageHeader = new MessageHeader(100_000_000L);
+        final var messageHeader = new MessageHeader(100_000_000L, "");
 
-        final EdifactValidationException exception = assertThrows(EdifactValidationException.class,
-                messageHeader::validate);
-
-        assertEquals("UNH: Attribute sequenceNumber must be between 1 and 99999999", exception.getMessage());
+        assertThatThrownBy(messageHeader::validate)
+            .isExactlyInstanceOf(EdifactValidationException.class)
+            .hasMessage("UNH: Attribute sequenceNumber must be between 1 and 99999999");
     }
 
     @Test
-    void testValidateSequenceNumberWithinMinMaxDoesNotThrowException() {
-        final MessageHeader messageHeader = new MessageHeader(9_999_999L);
+    void testValidateNoMessageTypeThrowsException() {
+        final var messageHeader = new MessageHeader(1L, null);
+
+        assertThatThrownBy(messageHeader::validate)
+            .isExactlyInstanceOf(EdifactValidationException.class)
+            .hasMessage("UNH: Attribute messageType is required");
+    }
+
+    @Test
+    void testValidateBlankMessageTypeThrowsException() {
+        final var messageHeader = new MessageHeader(1L, " ");
+
+        assertThatThrownBy(messageHeader::validate)
+            .isExactlyInstanceOf(EdifactValidationException.class)
+            .hasMessage("UNH: Attribute messageType is required");
+    }
+
+    @Test
+    void testValidateSequenceNumberWithValidValuesDoesNotThrowException() {
+        final var messageHeader = new MessageHeader(9_999_999L, "TEST");
 
         assertDoesNotThrow(messageHeader::validate);
     }
 
     @Test
     void testFromStringWithValidEdifactStringReturnsMessageHeader() {
-        final MessageHeader messageHeader = MessageHeader.fromString("UNH+00000003+FHSREG:0:1:FH:FHS001");
+        final var messageHeader = MessageHeader.fromString("UNH+00000003+FHSREG:0:1:FH:FHS001");
 
-        assertEquals("UNH", messageHeader.getKey());
-        assertEquals(SEQUENCE_NUMBER, messageHeader.getSequenceNumber());
+        assertAll(
+            () -> assertThat(messageHeader.getSequenceNumber()).isEqualTo(3),
+            () -> assertThat(messageHeader.getMessageType()).isEqualTo("FHS001")
+        );
     }
 
     @Test
     void testFromStringWithInvalidEdifactStringThrowsException() {
-        final IllegalArgumentException exception =
-                assertThrows(IllegalArgumentException.class, () -> MessageHeader.fromString("wrong value"));
-
-        assertEquals("Can't create MessageHeader from wrong value", exception.getMessage());
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> MessageHeader.fromString("wrong value"))
+            .withMessage("Can't create MessageHeader from wrong value");
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/outbound/queue/GpOutboundQueueServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/outbound/queue/GpOutboundQueueServiceTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 class GpOutboundQueueServiceTest {
 
     private static final String CONSERVATION_ID = "ABC123";
+    private static final String MESSAGE_TYPE = "NHS003";
     private static final String SENDER = "some_sender";
     private static final String RECIPIENT = "some_recipient";
     private static final long INTERCHANGE_SEQUENCE_NUMBER = 123;
@@ -86,6 +87,7 @@ class GpOutboundQueueServiceTest {
         when(interchangeHeader.getRecipient()).thenReturn(RECIPIENT);
         when(interchangeHeader.getSequenceNumber()).thenReturn(INTERCHANGE_SEQUENCE_NUMBER);
         when(messageHeader.getSequenceNumber()).thenReturn(MESSAGE_SEQUENCE_NUMBER);
+        when(messageHeader.getMessageType()).thenReturn(MESSAGE_TYPE);
 
         final var bundle = new Bundle();
         final var processingResult = new MessageProcessingResult.Success(message, bundle);
@@ -109,6 +111,7 @@ class GpOutboundQueueServiceTest {
         assertAll(
             () -> verify(session).createTextMessage(eq(serializedData)),
             () -> verify(textMessage).setStringProperty(JmsHeaders.CORRELATION_ID, CONSERVATION_ID),
+            () -> verify(textMessage).setStringProperty(JmsHeaders.MESSAGE_TYPE, MESSAGE_TYPE),
             () -> verify(correlationIdService).getCurrentCorrelationId(),
             () -> verify(checksumService)
                 .createChecksum(SENDER, RECIPIENT, INTERCHANGE_SEQUENCE_NUMBER, MESSAGE_SEQUENCE_NUMBER)

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/outbound/queue/GpOutboundQueueServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/outbound/queue/GpOutboundQueueServiceTest.java
@@ -1,6 +1,7 @@
 package uk.nhs.digital.nhsconnect.lab.results.outbound.queue;
 
 import org.hl7.fhir.dstu3.model.Bundle;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -17,6 +18,7 @@ import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Interchange;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.InterchangeHeader;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Message;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.MessageHeader;
+import uk.nhs.digital.nhsconnect.lab.results.model.edifact.MessageType;
 import uk.nhs.digital.nhsconnect.lab.results.utils.CorrelationIdService;
 import uk.nhs.digital.nhsconnect.lab.results.utils.JmsHeaders;
 
@@ -24,20 +26,17 @@ import javax.jms.JMSException;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("checkstyle:MagicNumber")
 class GpOutboundQueueServiceTest {
-
-    private static final String CONSERVATION_ID = "ABC123";
-    private static final String MESSAGE_TYPE = "NHS003";
-    private static final String SENDER = "some_sender";
-    private static final String RECIPIENT = "some_recipient";
-    private static final long INTERCHANGE_SEQUENCE_NUMBER = 123;
-    private static final long MESSAGE_SEQUENCE_NUMBER = 234;
 
     @InjectMocks
     private GpOutboundQueueService gpOutboundQueueService;
@@ -73,21 +72,25 @@ class GpOutboundQueueServiceTest {
     private MessageHeader messageHeader;
 
     @Captor
-    private ArgumentCaptor<MessageCreator> messageCreatorArgumentCaptor;
+    private ArgumentCaptor<MessageCreator> messageCreatorCaptor;
 
     @Value("${labresults.amqp.gpOutboundQueueName}")
     private String gpOutboundQueueName;
 
+    @BeforeEach
+    void setUp() {
+        lenient().when(message.getInterchange()).thenReturn(interchange);
+        lenient().when(interchange.getInterchangeHeader()).thenReturn(interchangeHeader);
+        when(message.getMessageHeader()).thenReturn(messageHeader);
+    }
+
     @Test
     void publishMessageToGpOutboundQueue() throws JMSException {
-        when(message.getInterchange()).thenReturn(interchange);
-        when(interchange.getInterchangeHeader()).thenReturn(interchangeHeader);
-        when(message.getMessageHeader()).thenReturn(messageHeader);
-        when(interchangeHeader.getSender()).thenReturn(SENDER);
-        when(interchangeHeader.getRecipient()).thenReturn(RECIPIENT);
-        when(interchangeHeader.getSequenceNumber()).thenReturn(INTERCHANGE_SEQUENCE_NUMBER);
-        when(messageHeader.getSequenceNumber()).thenReturn(MESSAGE_SEQUENCE_NUMBER);
-        when(messageHeader.getMessageType()).thenReturn(MESSAGE_TYPE);
+        when(interchangeHeader.getSender()).thenReturn("some_sender");
+        when(interchangeHeader.getRecipient()).thenReturn("some_recipient");
+        when(interchangeHeader.getSequenceNumber()).thenReturn(123L);
+        when(messageHeader.getSequenceNumber()).thenReturn(234L);
+        when(messageHeader.getMessageType()).thenReturn(MessageType.PATHOLOGY.getCode());
 
         final var bundle = new Bundle();
         final var processingResult = new MessageProcessingResult.Success(message, bundle);
@@ -95,26 +98,46 @@ class GpOutboundQueueServiceTest {
         final String serializedData = "some_serialized_data";
 
         when(serializer.serialize(bundle)).thenReturn(serializedData);
-        when(correlationIdService.getCurrentCorrelationId()).thenReturn(CONSERVATION_ID);
+        when(correlationIdService.getCurrentCorrelationId()).thenReturn("ABC123");
 
         gpOutboundQueueService.publish(processingResult);
 
         assertAll(
             () -> verify(serializer).serialize(bundle),
-            () -> verify(jmsTemplate).send(eq(gpOutboundQueueName), messageCreatorArgumentCaptor.capture())
+            () -> verify(jmsTemplate).send(eq(gpOutboundQueueName), messageCreatorCaptor.capture())
         );
 
         when(session.createTextMessage(serializedData)).thenReturn(textMessage);
 
-        messageCreatorArgumentCaptor.getValue().createMessage(session);
+        messageCreatorCaptor.getValue().createMessage(session);
 
         assertAll(
-            () -> verify(session).createTextMessage(eq(serializedData)),
-            () -> verify(textMessage).setStringProperty(JmsHeaders.CORRELATION_ID, CONSERVATION_ID),
-            () -> verify(textMessage).setStringProperty(JmsHeaders.MESSAGE_TYPE, MESSAGE_TYPE),
+            () -> verify(session).createTextMessage(serializedData),
+            () -> verify(textMessage).setStringProperty(JmsHeaders.CORRELATION_ID, "ABC123"),
+            () -> verify(textMessage).setStringProperty(JmsHeaders.MESSAGE_TYPE, "Pathology"),
             () -> verify(correlationIdService).getCurrentCorrelationId(),
             () -> verify(checksumService)
-                .createChecksum(SENDER, RECIPIENT, INTERCHANGE_SEQUENCE_NUMBER, MESSAGE_SEQUENCE_NUMBER)
+                .createChecksum("some_sender", "some_recipient", 123L, 234L)
         );
+    }
+
+    @Test
+    void publishInvalidMessageToGpOutboundQueue() {
+        when(messageHeader.getMessageType()).thenReturn(MessageType.NHSACK.getCode());
+        final var processingResult = new MessageProcessingResult.Success(message, new Bundle());
+
+        assertThatIllegalStateException()
+            .isThrownBy(() -> gpOutboundQueueService.publish(processingResult))
+            .withMessage("Invalid message type: NHSACK");
+    }
+
+    @Test
+    void publishNonsenseMessageToGpOutboundQueue() {
+        when(messageHeader.getMessageType()).thenReturn("Nonsense");
+        final var processingResult = new MessageProcessingResult.Success(message, new Bundle());
+
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> gpOutboundQueueService.publish(processingResult))
+            .withMessage("No message type for \"Nonsense\"");
     }
 }


### PR DESCRIPTION
## Description

A third header, `MessageType`, is added to the JMS
item for the GP outbound queue with the original
from the edifact message header, e.g. "NHS003"

## Jira Ticket

https://gpitbjss.atlassian.net/browse/NIAD-1152

## Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [x] Acceptance Criteria met
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] Self-reviewed your code
- [ ] Code reviewed from two other developers
- [x] If your pull request depends on any other, please link them in the description
- [x] main branch is passing/green on CI
- [x] Add/update any relevant documentation

## Evidence

![image](https://user-images.githubusercontent.com/38751994/110968477-7bf15280-834f-11eb-91b5-dafabc479ee8.png)
