### PR TITLE
NIAD-1179: Use intent of original-order instead of null

### DIFF
--- a/src/intTest/resources/fhir/multi_pathology_msg1.fhir.json
+++ b/src/intTest/resources/fhir/multi_pathology_msg1.fhir.json
@@ -97,7 +97,7 @@
         "resourceType": "ProcedureRequest",
         "id": "8aac2da2-5857-4c71-af22-461557c791ee",
         "status": "unknown",
-        "intent": "?",
+        "intent": "original-order",
         "code": {
           "text": "unknown"
         },

--- a/src/intTest/resources/fhir/multi_pathology_msg2.fhir.json
+++ b/src/intTest/resources/fhir/multi_pathology_msg2.fhir.json
@@ -92,7 +92,7 @@
         "resourceType": "ProcedureRequest",
         "id": "a519747b-ec83-477b-bf7a-b3fc6b7abeac",
         "status": "unknown",
-        "intent": "?",
+        "intent": "original-order",
         "code": {
           "text": "unknown"
         },

--- a/src/intTest/resources/fhir/pathology.fhir.json
+++ b/src/intTest/resources/fhir/pathology.fhir.json
@@ -97,7 +97,7 @@
         "resourceType": "ProcedureRequest",
         "id": "8be835ba-540a-4a02-bf0c-0be947b98c82",
         "status": "unknown",
-        "intent": "?",
+        "intent": "original-order",
         "code": {
           "text": "unknown"
         },

--- a/src/intTest/resources/success_uat_data/NHS003/full_acceptance_with_nhsack.1.fhir.json
+++ b/src/intTest/resources/success_uat_data/NHS003/full_acceptance_with_nhsack.1.fhir.json
@@ -87,7 +87,7 @@
         "resourceType": "ProcedureRequest",
         "id": "d25187de-ce0a-4eea-838b-e7569d03cfec",
         "status": "unknown",
-        "intent": "?",
+        "intent": "original-order",
         "code": {
           "text": "unknown"
         },

--- a/src/intTest/resources/success_uat_data/NHS003/full_acceptance_with_nhsack.2.fhir.json
+++ b/src/intTest/resources/success_uat_data/NHS003/full_acceptance_with_nhsack.2.fhir.json
@@ -87,7 +87,7 @@
         "resourceType": "ProcedureRequest",
         "id": "46de5ca6-fb83-4ab0-b826-52adae5a9a4e",
         "status": "unknown",
-        "intent": "?",
+        "intent": "original-order",
         "code": {
           "text": "unknown"
         },

--- a/src/intTest/resources/success_uat_data/NHS003/full_acceptance_with_nhsack.3.fhir.json
+++ b/src/intTest/resources/success_uat_data/NHS003/full_acceptance_with_nhsack.3.fhir.json
@@ -87,7 +87,7 @@
         "resourceType": "ProcedureRequest",
         "id": "3cb08233-f421-4f3b-bf93-eed2b46b8e55",
         "status": "unknown",
-        "intent": "?",
+        "intent": "original-order",
         "code": {
           "text": "unknown"
         },

--- a/src/intTest/resources/success_uat_data/NHS003/full_acceptance_without_nhsack.1.fhir.json
+++ b/src/intTest/resources/success_uat_data/NHS003/full_acceptance_without_nhsack.1.fhir.json
@@ -87,7 +87,7 @@
         "resourceType": "ProcedureRequest",
         "id": "ab2ce0dd-c80c-42c3-929f-ba08459e72f2",
         "status": "unknown",
-        "intent": "?",
+        "intent": "original-order",
         "code": {
           "text": "unknown"
         },

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/ProcedureRequestMapper.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/ProcedureRequestMapper.java
@@ -7,6 +7,8 @@ import org.hl7.fhir.dstu3.model.Organization;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Practitioner;
 import org.hl7.fhir.dstu3.model.ProcedureRequest;
+import org.hl7.fhir.dstu3.model.ProcedureRequest.ProcedureRequestIntent;
+import org.hl7.fhir.dstu3.model.ProcedureRequest.ProcedureRequestStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.FreeTextSegment;
@@ -20,9 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import org.hl7.fhir.dstu3.model.ProcedureRequest.ProcedureRequestStatus;
-import org.hl7.fhir.dstu3.model.ProcedureRequest.ProcedureRequestIntent;
 
 @Component
 @RequiredArgsConstructor(onConstructor_ = @Autowired)
@@ -66,7 +65,8 @@ public class ProcedureRequestMapper {
             this.procedureRequest = new ProcedureRequest();
             mapFreeText();
             mapStatus();
-            procedureRequest.setIntent(ProcedureRequestIntent.NULL);
+            // TODO: this is just a valid value used until we know the real one, or how to determine the real one
+            procedureRequest.setIntent(ProcedureRequestIntent.ORIGINALORDER);
             procedureRequest.setCode(new CodeableConcept().setText("unknown"));
             procedureRequest.setId(uuidGenerator.generateUUID());
             procedureRequest.getSubject().setReference(fullUrlGenerator.generate(patient));

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/ProcedureRequestMapper.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/ProcedureRequestMapper.java
@@ -65,7 +65,7 @@ public class ProcedureRequestMapper {
             this.procedureRequest = new ProcedureRequest();
             mapFreeText();
             mapStatus();
-            // TODO: this is just a valid value used until we know the real one, or how to determine the real one
+            // TODO NIAD-1179: just a valid value used until we know the real one, or how to determine the real one
             procedureRequest.setIntent(ProcedureRequestIntent.ORIGINALORDER);
             procedureRequest.setCode(new CodeableConcept().setText("unknown"));
             procedureRequest.setId(uuidGenerator.generateUUID());

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/ProcedureRequestMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/ProcedureRequestMapperTest.java
@@ -5,6 +5,7 @@ import org.hl7.fhir.dstu3.model.Organization;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Practitioner;
 import org.hl7.fhir.dstu3.model.ProcedureRequest;
+import org.hl7.fhir.dstu3.model.ProcedureRequest.ProcedureRequestIntent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -26,8 +27,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import org.hl7.fhir.dstu3.model.ProcedureRequest.ProcedureRequestIntent;
 
 @SuppressWarnings("checkstyle:magicnumber")
 @ExtendWith(MockitoExtension.class)
@@ -181,7 +180,7 @@ class ProcedureRequestMapperTest {
         assertThat(procedureRequest)
             .isNotEmpty()
             .hasValueSatisfying(procedure ->
-                assertThat(procedure.getIntent()).isEqualTo(ProcedureRequestIntent.NULL));
+                assertThat(procedure.getIntent()).isEqualTo(ProcedureRequestIntent.ORIGINALORDER));
     }
 
     @Test


### PR DESCRIPTION
## Description

This is a hotfix to send valid FHIR STU3 messages, but the value
might need to be changed again when we know what it should be.

Hotfix for #79 

## Jira Ticket

https://gpitbjss.atlassian.net/browse/NIAD-1179

## Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [x] Acceptance Criteria met
- [x] Commit messages are meaningful
- [ ] Manually tested
- [x] Self-reviewed your code
- [ ] Code reviewed from two other developers
- [x] If your pull request depends on any other, please link them in the description
- [x] main branch is passing/green on CI
- [x] Add/update any relevant documentation
