### PR TITLE
NIAD-000: Update pathology record naming.

### DIFF
--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/inbound/fhir/EdifactToFhirService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/inbound/fhir/EdifactToFhirService.java
@@ -5,20 +5,20 @@ import org.hl7.fhir.dstu3.model.Bundle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Message;
-import uk.nhs.digital.nhsconnect.lab.results.model.PathologyRecord;
+import uk.nhs.digital.nhsconnect.lab.results.model.MedicalReport;
 import uk.nhs.digital.nhsconnect.lab.results.translator.mapper.BundleMapper;
-import uk.nhs.digital.nhsconnect.lab.results.translator.mapper.PathologyRecordMapper;
+import uk.nhs.digital.nhsconnect.lab.results.translator.mapper.MedicalReportMapper;
 
 @Component
 @RequiredArgsConstructor(onConstructor_ = @Autowired)
 public class EdifactToFhirService {
 
-    private final PathologyRecordMapper pathologyRecordMapper;
+    private final MedicalReportMapper medicalReportMapper;
     private final BundleMapper bundleMapper;
 
     public Bundle convertToFhir(final Message message) {
-        PathologyRecord pathologyRecord = pathologyRecordMapper.mapToPathologyRecord(message);
+        MedicalReport medicalReport = medicalReportMapper.mapToMedicalReport(message);
 
-        return bundleMapper.mapToBundle(pathologyRecord);
+        return bundleMapper.mapToBundle(medicalReport);
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/MedicalReport.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/model/MedicalReport.java
@@ -17,15 +17,13 @@ import java.util.List;
 @Builder
 @Getter
 @Setter
-public class PathologyRecord {
+public class MedicalReport {
 
     private Patient patient;
     private Practitioner performingPractitioner;
     private Organization performingOrganization;
     private Practitioner requestingPractitioner;
     private Organization requestingOrganization;
-    private Organization specimenCollectingOrganization;
-    private Practitioner specimenCollector;
     @Builder.Default
     private List<Specimen> specimens = Collections.emptyList();
     private DiagnosticReport testReport;

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/BundleMapper.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/BundleMapper.java
@@ -8,7 +8,7 @@ import org.hl7.fhir.dstu3.model.Meta;
 import org.hl7.fhir.dstu3.model.Resource;
 import org.hl7.fhir.dstu3.model.UriType;
 import org.springframework.stereotype.Component;
-import uk.nhs.digital.nhsconnect.lab.results.model.PathologyRecord;
+import uk.nhs.digital.nhsconnect.lab.results.model.MedicalReport;
 import uk.nhs.digital.nhsconnect.lab.results.utils.ResourceFullUrlGenerator;
 import uk.nhs.digital.nhsconnect.lab.results.utils.UUIDGenerator;
 
@@ -26,22 +26,22 @@ public class BundleMapper {
     private final UUIDGenerator uuidGenerator;
     private final ResourceFullUrlGenerator fullUrlGenerator;
 
-    public Bundle mapToBundle(final PathologyRecord pathologyRecord) {
+    public Bundle mapToBundle(final MedicalReport medicalReport) {
         final Bundle bundle = generateInitialPathologyBundle();
         final Consumer<Resource> addToBundle = resource -> addResourceToBundle(bundle, resource);
 
-        addToBundle.accept(pathologyRecord.getPatient());
+        addToBundle.accept(medicalReport.getPatient());
 
-        Optional.ofNullable(pathologyRecord.getRequestingPractitioner()).ifPresent(addToBundle);
-        Optional.ofNullable(pathologyRecord.getRequestingOrganization()).ifPresent(addToBundle);
-        Optional.ofNullable(pathologyRecord.getPerformingPractitioner()).ifPresent(addToBundle);
-        Optional.ofNullable(pathologyRecord.getPerformingOrganization()).ifPresent(addToBundle);
-        Optional.ofNullable(pathologyRecord.getTestRequestSummary()).ifPresent(addToBundle);
-        Optional.ofNullable(pathologyRecord.getTestReport()).ifPresent(addToBundle);
+        Optional.ofNullable(medicalReport.getRequestingPractitioner()).ifPresent(addToBundle);
+        Optional.ofNullable(medicalReport.getRequestingOrganization()).ifPresent(addToBundle);
+        Optional.ofNullable(medicalReport.getPerformingPractitioner()).ifPresent(addToBundle);
+        Optional.ofNullable(medicalReport.getPerformingOrganization()).ifPresent(addToBundle);
+        Optional.ofNullable(medicalReport.getTestRequestSummary()).ifPresent(addToBundle);
+        Optional.ofNullable(medicalReport.getTestReport()).ifPresent(addToBundle);
 
-        pathologyRecord.getSpecimens().forEach(addToBundle);
+        medicalReport.getSpecimens().forEach(addToBundle);
 
-        pathologyRecord.getTestResults().forEach(addToBundle);
+        medicalReport.getTestResults().forEach(addToBundle);
 
         return bundle;
     }

--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/MedicalReportMapper.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/MedicalReportMapper.java
@@ -5,12 +5,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Message;
-import uk.nhs.digital.nhsconnect.lab.results.model.PathologyRecord;
-import uk.nhs.digital.nhsconnect.lab.results.model.PathologyRecord.PathologyRecordBuilder;
+import uk.nhs.digital.nhsconnect.lab.results.model.MedicalReport;
+import uk.nhs.digital.nhsconnect.lab.results.model.MedicalReport.MedicalReportBuilder;
 
 @Component
 @RequiredArgsConstructor(onConstructor_ = @Autowired)
-public class PathologyRecordMapper {
+public class MedicalReportMapper {
 
     private final PractitionerMapper practitionerMapper;
     private final ProcedureRequestMapper procedureRequestMapper;
@@ -20,7 +20,7 @@ public class PathologyRecordMapper {
     private final DiagnosticReportMapper diagnosticReportMapper;
     private final ObservationMapper observationMapper;
 
-    public PathologyRecord mapToPathologyRecord(final Message message) {
+    public MedicalReport mapToMedicalReport(final Message message) {
         final var patient = patientMapper.mapToPatient(message);
         final var requestingPractitioner = practitionerMapper.mapToRequestingPractitioner(message);
         final var requestingOrganization = organizationMapper.mapToRequestingOrganization(message);
@@ -37,18 +37,18 @@ public class PathologyRecordMapper {
             observations, performingPractitioner.orElse(null), performingOrganization.orElse(null),
             procedureRequest.orElse(null));
 
-        final PathologyRecordBuilder pathologyRecordBuilder = PathologyRecord.builder();
+        final MedicalReportBuilder medicalReportBuilder = MedicalReport.builder();
 
-        pathologyRecordBuilder.patient(patient);
-        requestingPractitioner.ifPresent(pathologyRecordBuilder::requestingPractitioner);
-        requestingOrganization.ifPresent(pathologyRecordBuilder::requestingOrganization);
-        performingPractitioner.ifPresent(pathologyRecordBuilder::performingPractitioner);
-        performingOrganization.ifPresent(pathologyRecordBuilder::performingOrganization);
-        procedureRequest.ifPresent(pathologyRecordBuilder::testRequestSummary);
-        pathologyRecordBuilder.testReport(diagnosticReport);
-        pathologyRecordBuilder.specimens(specimens);
-        pathologyRecordBuilder.testResults(observations);
+        medicalReportBuilder.patient(patient);
+        requestingPractitioner.ifPresent(medicalReportBuilder::requestingPractitioner);
+        requestingOrganization.ifPresent(medicalReportBuilder::requestingOrganization);
+        performingPractitioner.ifPresent(medicalReportBuilder::performingPractitioner);
+        performingOrganization.ifPresent(medicalReportBuilder::performingOrganization);
+        procedureRequest.ifPresent(medicalReportBuilder::testRequestSummary);
+        medicalReportBuilder.testReport(diagnosticReport);
+        medicalReportBuilder.specimens(specimens);
+        medicalReportBuilder.testResults(observations);
 
-        return pathologyRecordBuilder.build();
+        return medicalReportBuilder.build();
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/fhir/EdifactToFhirServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/inbound/fhir/EdifactToFhirServiceTest.java
@@ -7,9 +7,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.digital.nhsconnect.lab.results.model.edifact.Message;
-import uk.nhs.digital.nhsconnect.lab.results.model.PathologyRecord;
+import uk.nhs.digital.nhsconnect.lab.results.model.MedicalReport;
 import uk.nhs.digital.nhsconnect.lab.results.translator.mapper.BundleMapper;
-import uk.nhs.digital.nhsconnect.lab.results.translator.mapper.PathologyRecordMapper;
+import uk.nhs.digital.nhsconnect.lab.results.translator.mapper.MedicalReportMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
 class EdifactToFhirServiceTest {
 
     @Mock
-    private PathologyRecordMapper pathologyRecordMapper;
+    private MedicalReportMapper medicalReportMapper;
 
     @Mock
     private BundleMapper bundleMapper;
@@ -32,16 +32,16 @@ class EdifactToFhirServiceTest {
     @Test
     void testEdifactIsMappedToFhirBundle() {
         final var message = mock(Message.class);
-        final var pathologyRecord = mock(PathologyRecord.class);
+        final var medicalReport = mock(MedicalReport.class);
         final var generatedBundle = mock(Bundle.class);
-        when(pathologyRecordMapper.mapToPathologyRecord(message)).thenReturn(pathologyRecord);
-        when(bundleMapper.mapToBundle(pathologyRecord)).thenReturn(generatedBundle);
+        when(medicalReportMapper.mapToMedicalReport(message)).thenReturn(medicalReport);
+        when(bundleMapper.mapToBundle(medicalReport)).thenReturn(generatedBundle);
 
         final Bundle bundle = service.convertToFhir(message);
 
         assertAll(
             () -> assertThat(bundle).isSameAs(generatedBundle),
-            () -> verifyNoInteractions(pathologyRecord),
+            () -> verifyNoInteractions(medicalReport),
             () -> verifyNoInteractions(generatedBundle)
         );
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/BundleMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/BundleMapperTest.java
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.nhs.digital.nhsconnect.lab.results.model.PathologyRecord;
-import uk.nhs.digital.nhsconnect.lab.results.model.PathologyRecord.PathologyRecordBuilder;
+import uk.nhs.digital.nhsconnect.lab.results.model.MedicalReport;
+import uk.nhs.digital.nhsconnect.lab.results.model.MedicalReport.MedicalReportBuilder;
 import uk.nhs.digital.nhsconnect.lab.results.utils.ResourceFullUrlGenerator;
 import uk.nhs.digital.nhsconnect.lab.results.utils.UUIDGenerator;
 
@@ -46,7 +46,7 @@ class BundleMapperTest {
     @InjectMocks
     private BundleMapper bundleMapper;
 
-    private PathologyRecordBuilder pathologyRecordBuilder;
+    private MedicalReportBuilder medicalReportBuilder;
 
     @BeforeEach
     void setUp() {
@@ -55,18 +55,18 @@ class BundleMapperTest {
         // add members that are required:
         final var mockRequester = mock(Practitioner.class);
         lenient().when(mockRequester.getId()).thenReturn(SOME_UUID);
-        pathologyRecordBuilder = PathologyRecord.builder()
+        medicalReportBuilder = MedicalReport.builder()
             .requestingPractitioner(mockRequester)
             .patient(mock(Patient.class))
             .testReport(mock(DiagnosticReport.class));
     }
 
     @Test
-    void testMapPathologyRecordToBundleWithPatient() {
+    void testMapMedicalReportToBundleWithPatient() {
         final var mockPatient = mock(Patient.class);
-        pathologyRecordBuilder.patient(mockPatient);
+        medicalReportBuilder.patient(mockPatient);
 
-        final Bundle bundle = bundleMapper.mapToBundle(pathologyRecordBuilder.build());
+        final Bundle bundle = bundleMapper.mapToBundle(medicalReportBuilder.build());
 
         final var patientBundleEntries = bundle.getEntry().stream()
             .filter(entry -> entry.getResource() instanceof Patient)
@@ -86,11 +86,11 @@ class BundleMapperTest {
     }
 
     @Test
-    void testMapPathologyRecordToBundleWithRequestingPractitioner() {
+    void testMapMedicalReportToBundleWithRequestingPractitioner() {
         final var mockRequestingPractitioner = mock(Practitioner.class);
-        pathologyRecordBuilder.requestingPractitioner(mockRequestingPractitioner);
+        medicalReportBuilder.requestingPractitioner(mockRequestingPractitioner);
 
-        final var bundle = bundleMapper.mapToBundle(pathologyRecordBuilder.build());
+        final var bundle = bundleMapper.mapToBundle(medicalReportBuilder.build());
 
         final var requesterBundleEntries = bundle.getEntry().stream()
             .filter(entry -> entry.getResource() instanceof Practitioner)
@@ -110,11 +110,11 @@ class BundleMapperTest {
     }
 
     @Test
-    void testMapPathologyRecordToBundleWithRequestingOrganization() {
+    void testMapMedicalReportToBundleWithRequestingOrganization() {
         final var mockRequestingOrganization = mock(Organization.class);
-        pathologyRecordBuilder.requestingOrganization(mockRequestingOrganization);
+        medicalReportBuilder.requestingOrganization(mockRequestingOrganization);
 
-        final var bundle = bundleMapper.mapToBundle(pathologyRecordBuilder.build());
+        final var bundle = bundleMapper.mapToBundle(medicalReportBuilder.build());
 
         final var requestingOrganizationBundleEntries = bundle.getEntry().stream()
             .filter(entry -> entry.getResource() instanceof Organization)
@@ -134,11 +134,11 @@ class BundleMapperTest {
     }
 
     @Test
-    void testMapPathologyRecordToBundleWithPerformingPractitioner() {
+    void testMapMedicalReportToBundleWithPerformingPractitioner() {
         final var mockPerformingPractitioner = mock(Practitioner.class);
-        pathologyRecordBuilder.performingPractitioner(mockPerformingPractitioner);
+        medicalReportBuilder.performingPractitioner(mockPerformingPractitioner);
 
-        final var bundle = bundleMapper.mapToBundle(pathologyRecordBuilder.build());
+        final var bundle = bundleMapper.mapToBundle(medicalReportBuilder.build());
 
         final var performerBundleEntries = bundle.getEntry().stream()
             .filter(entry -> entry.getResource() instanceof Practitioner)
@@ -159,11 +159,11 @@ class BundleMapperTest {
     }
 
     @Test
-    void testMapPathologyRecordToBundleWithPerformingOrganization() {
+    void testMapMedicalReportToBundleWithPerformingOrganization() {
         final var mockPerformingOrganization = mock(Organization.class);
-        pathologyRecordBuilder.performingOrganization(mockPerformingOrganization);
+        medicalReportBuilder.performingOrganization(mockPerformingOrganization);
 
-        final var bundle = bundleMapper.mapToBundle(pathologyRecordBuilder.build());
+        final var bundle = bundleMapper.mapToBundle(medicalReportBuilder.build());
 
         final var performingOrganizationBundleEntries = bundle.getEntry().stream()
             .filter(entry -> entry.getResource() instanceof Organization)
@@ -183,11 +183,11 @@ class BundleMapperTest {
     }
 
     @Test
-    void testMapPathologyRecordToBundleWithProcedureRequest() {
+    void testMapMedicalReportToBundleWithProcedureRequest() {
         final var mockProcedureRequest = mock(ProcedureRequest.class);
-        pathologyRecordBuilder.testRequestSummary(mockProcedureRequest);
+        medicalReportBuilder.testRequestSummary(mockProcedureRequest);
 
-        final var bundle = bundleMapper.mapToBundle(pathologyRecordBuilder.build());
+        final var bundle = bundleMapper.mapToBundle(medicalReportBuilder.build());
 
         final var procedureRequestBundleEntries = bundle.getEntry().stream()
             .filter(entry -> entry.getResource() instanceof ProcedureRequest)
@@ -208,12 +208,12 @@ class BundleMapperTest {
     }
 
     @Test
-    void testMapPathologyRecordToBundleWithSpecimens() {
+    void testMapMedicalReportToBundleWithSpecimens() {
         final var mockSpecimen1 = mock(Specimen.class);
         final var mockSpecimen2 = mock(Specimen.class);
-        pathologyRecordBuilder.specimens(List.of(mockSpecimen1, mockSpecimen2));
+        medicalReportBuilder.specimens(List.of(mockSpecimen1, mockSpecimen2));
 
-        final var bundle = bundleMapper.mapToBundle(pathologyRecordBuilder.build());
+        final var bundle = bundleMapper.mapToBundle(medicalReportBuilder.build());
 
         final var specimenBundleEntries = bundle.getEntry().stream()
             .filter(entry -> entry.getResource() instanceof Specimen)
@@ -234,12 +234,12 @@ class BundleMapperTest {
     }
 
     @Test
-    void testMapPathologyRecordToBundleWithTestResults() {
+    void testMapMedicalReportToBundleWithTestResults() {
         final var mockTestResult1 = mock(Observation.class);
         final var mockTestResult2 = mock(Observation.class);
-        pathologyRecordBuilder.testResults(List.of(mockTestResult1, mockTestResult2));
+        medicalReportBuilder.testResults(List.of(mockTestResult1, mockTestResult2));
 
-        final var bundle = bundleMapper.mapToBundle(pathologyRecordBuilder.build());
+        final var bundle = bundleMapper.mapToBundle(medicalReportBuilder.build());
 
         final var observationBundleEntries = bundle.getEntry().stream()
             .filter(entry -> entry.getResource() instanceof Observation)
@@ -260,11 +260,11 @@ class BundleMapperTest {
     }
 
     @Test
-    void testMapPathologyRecordToBundleWithDiagnosticReport() {
+    void testMapMedicalReportToBundleWithDiagnosticReport() {
         final var mockDiagnosticReport = mock(DiagnosticReport.class);
-        pathologyRecordBuilder.testReport(mockDiagnosticReport);
+        medicalReportBuilder.testReport(mockDiagnosticReport);
 
-        final Bundle bundle = bundleMapper.mapToBundle(pathologyRecordBuilder.build());
+        final Bundle bundle = bundleMapper.mapToBundle(medicalReportBuilder.build());
 
         final var diagnosticReportBundleEntries = bundle.getEntry().stream()
             .filter(entry -> entry.getResource() instanceof DiagnosticReport)

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/MedicalReportMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/translator/mapper/MedicalReportMapperTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class PathologyRecordMapperTest {
+class MedicalReportMapperTest {
 
     @Mock
     private PatientMapper patientMapper;
@@ -56,7 +56,7 @@ class PathologyRecordMapperTest {
     private DiagnosticReportMapper diagnosticReportMapper;
 
     @InjectMocks
-    private PathologyRecordMapper pathologyRecordMapper;
+    private MedicalReportMapper medicalReportMapper;
 
     @BeforeEach
     void setUp() {
@@ -77,70 +77,70 @@ class PathologyRecordMapperTest {
     }
 
     @Test
-    void testMapMessageToPathologyRecordWithPatient() {
+    void testMapMessageToMedicalReportWithPatient() {
         final Message message = new Message(emptyList());
         var mockPatient = mock(Patient.class);
         when(patientMapper.mapToPatient(message)).thenReturn(mockPatient);
 
-        final var pathologyRecord = pathologyRecordMapper.mapToPathologyRecord(message);
+        final var medicalReport = medicalReportMapper.mapToMedicalReport(message);
 
-        assertThat(pathologyRecord.getPatient()).isEqualTo(mockPatient);
+        assertThat(medicalReport.getPatient()).isEqualTo(mockPatient);
     }
 
     @Test
-    void testMapMessageToPathologyRecordWithRequester() {
+    void testMapMessageToMedicalReportWithRequester() {
         final Message message = new Message(emptyList());
         var mockRequestingPractitioner = mock(Practitioner.class);
 
         when(practitionerMapper.mapToRequestingPractitioner(message))
             .thenReturn(Optional.of(mockRequestingPractitioner));
 
-        final var pathologyRecord = pathologyRecordMapper.mapToPathologyRecord(message);
+        final var medicalReport = medicalReportMapper.mapToMedicalReport(message);
 
-        assertThat(pathologyRecord.getRequestingPractitioner()).isEqualTo(mockRequestingPractitioner);
+        assertThat(medicalReport.getRequestingPractitioner()).isEqualTo(mockRequestingPractitioner);
     }
 
     @Test
-    void testMapMessageToPathologyRecordWithRequestingOrganization() {
+    void testMapMessageToMedicalReportWithRequestingOrganization() {
         final Message message = new Message(emptyList());
         var mockRequestingOrganization = mock(Organization.class);
 
         when(organizationMapper.mapToRequestingOrganization(message))
             .thenReturn(Optional.of(mockRequestingOrganization));
 
-        final var pathologyRecord = pathologyRecordMapper.mapToPathologyRecord(message);
+        final var medicalReport = medicalReportMapper.mapToMedicalReport(message);
 
-        assertThat(pathologyRecord.getRequestingOrganization()).isEqualTo(mockRequestingOrganization);
+        assertThat(medicalReport.getRequestingOrganization()).isEqualTo(mockRequestingOrganization);
     }
 
     @Test
-    void testMapMessageToPathologyRecordWithPerformer() {
+    void testMapMessageToMedicalReportWithPerformer() {
         final Message message = new Message(emptyList());
         var mockPerformingPractitioner = mock(Practitioner.class);
 
         when(practitionerMapper.mapToPerformingPractitioner(message))
             .thenReturn(Optional.of(mockPerformingPractitioner));
 
-        final var pathologyRecord = pathologyRecordMapper.mapToPathologyRecord(message);
+        final var medicalReport = medicalReportMapper.mapToMedicalReport(message);
 
-        assertThat(pathologyRecord.getPerformingPractitioner()).isEqualTo(mockPerformingPractitioner);
+        assertThat(medicalReport.getPerformingPractitioner()).isEqualTo(mockPerformingPractitioner);
     }
 
     @Test
-    void testMapMessageToPathologyRecordWithPerformingOrganization() {
+    void testMapMessageToMedicalReportWithPerformingOrganization() {
         final Message message = new Message(emptyList());
         var mockPerformingOrganization = mock(Organization.class);
 
         when(organizationMapper.mapToPerformingOrganization(message))
             .thenReturn(Optional.of(mockPerformingOrganization));
 
-        final var pathologyRecord = pathologyRecordMapper.mapToPathologyRecord(message);
+        final var medicalReport = medicalReportMapper.mapToMedicalReport(message);
 
-        assertThat(pathologyRecord.getPerformingOrganization()).isEqualTo(mockPerformingOrganization);
+        assertThat(medicalReport.getPerformingOrganization()).isEqualTo(mockPerformingOrganization);
     }
 
     @Test
-    void testMapMessageToPathologyRecordWithProcedureRequest() {
+    void testMapMessageToMedicalReportWithProcedureRequest() {
         final Message message = new Message(emptyList());
         var mockProcedureRequest = mock(ProcedureRequest.class);
         reset(procedureRequestMapper);
@@ -149,13 +149,13 @@ class PathologyRecordMapperTest {
             nullable(Practitioner.class), nullable(Organization.class)))
             .thenReturn(Optional.of(mockProcedureRequest));
 
-        final var pathologyRecord = pathologyRecordMapper.mapToPathologyRecord(message);
+        final var medicalReport = medicalReportMapper.mapToMedicalReport(message);
 
-        assertThat(pathologyRecord.getTestRequestSummary()).isEqualTo(mockProcedureRequest);
+        assertThat(medicalReport.getTestRequestSummary()).isEqualTo(mockProcedureRequest);
     }
 
     @Test
-    void testMapMessageToPathologyRecordWithSpecimens() {
+    void testMapMessageToMedicalReportWithSpecimens() {
         final Message message = new Message(emptyList());
         final var mockSpecimen1 = mock(Specimen.class);
         final var mockSpecimen2 = mock(Specimen.class);
@@ -163,14 +163,14 @@ class PathologyRecordMapperTest {
         when(specimenMapper.mapToSpecimensBySequenceNumber(eq(message), any(Patient.class)))
             .thenReturn(Map.of("1", mockSpecimen1, "2", mockSpecimen2));
 
-        final var pathologyRecord = pathologyRecordMapper.mapToPathologyRecord(message);
+        final var medicalReport = medicalReportMapper.mapToMedicalReport(message);
 
-        assertThat(pathologyRecord.getSpecimens())
+        assertThat(medicalReport.getSpecimens())
             .containsOnly(mockSpecimen1, mockSpecimen2);
     }
 
     @Test
-    void testMapMessageToPathologyRecordWithTestResults() {
+    void testMapMessageToMedicalReportWithTestResults() {
         final Message message = new Message(emptyList());
         final var mockObservation1 = mock(Observation.class);
         final var mockObservation2 = mock(Observation.class);
@@ -179,14 +179,14 @@ class PathologyRecordMapperTest {
             nullable(Organization.class), nullable(Practitioner.class)))
             .thenReturn(List.of(mockObservation1, mockObservation2));
 
-        final var pathologyRecord = pathologyRecordMapper.mapToPathologyRecord(message);
+        final var medicalReport = medicalReportMapper.mapToMedicalReport(message);
 
-        assertThat(pathologyRecord.getTestResults())
+        assertThat(medicalReport.getTestResults())
             .containsExactly(mockObservation1, mockObservation2);
     }
 
     @Test
-    void testMapMessageToPathologyRecordWithDiagnosticReport() {
+    void testMapMessageToMedicalReportWithDiagnosticReport() {
         final Message message = new Message(emptyList());
         final var diagnosticReport = mock(DiagnosticReport.class);
         reset(diagnosticReportMapper);
@@ -194,8 +194,8 @@ class PathologyRecordMapperTest {
             nullable(Practitioner.class), nullable(Organization.class), nullable(ProcedureRequest.class)))
             .thenReturn(diagnosticReport);
 
-        final var pathologyRecord = pathologyRecordMapper.mapToPathologyRecord(message);
+        final var medicalReport = medicalReportMapper.mapToMedicalReport(message);
 
-        assertThat(pathologyRecord.getTestReport()).isEqualTo(diagnosticReport);
+        assertThat(medicalReport.getTestReport()).isEqualTo(diagnosticReport);
     }
 }


### PR DESCRIPTION
## Description

As the adaptor will handle pathology and screening messages, we should rename the pathology record model and mapper to "MedicalReport".

Also removed the unused "SpecimenCollector" and "SpecimenCollectingOrganization" properties.

## Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [ ] Acceptance Criteria met
- [ ] Commit messages are meaningful
- [ ] Manually tested
- [ ] Self-reviewed your code
- [ ] Code reviewed from two other developers
- [ ] If your pull request depends on any other, please link them in the description
- [ ] main branch is passing/green on CI
- [ ] Add/update any relevant documentation
