### PR TITLE
NIAD-0000: Add missing '@DependsOn({"appInitializer"})' to LabResultsMongoClientConfiguration.java

### DIFF
--- a/src/main/java/uk/nhs/digital/nhsconnect/lab/results/configuration/LabResultsMongoClientConfiguration.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/lab/results/configuration/LabResultsMongoClientConfiguration.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
 
 import java.time.Duration;
@@ -17,6 +18,7 @@ import java.time.Duration;
 @Getter
 @Setter
 @Slf4j
+@DependsOn({"appInitializer"}) // so that custom TrustStore is loaded before DB connection is initialized
 public class LabResultsMongoClientConfiguration extends AbstractMongoClientConfiguration {
 
     private String database;


### PR DESCRIPTION
## Description

Add missing `@DependsOn({"appInitializer"})` annotation to LabResultsMongoClientConfiguration so that the custom TrustStore is loaded before the DB connection is initialised.

## Jira Ticket

N/A

## Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [ ] Acceptance Criteria met
- [ ] Commit messages are meaningful
- [ ] Manually tested
- [ ] Self-reviewed your code
- [ ] Code reviewed from two other developers
- [ ] If your pull request depends on any other, please link them in the description
- [ ] main branch is passing/green on CI
- [ ] Add/update any relevant documentation
